### PR TITLE
feat: WSL native messaging, tool execution fix, model selector, stop button, session routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Your AI copilot for the web — a Chrome/Edge browser extension that brings GitH
 - **Screenshots**: Capture visible viewport or specific elements
 - **Visual Feedback**: Highlight elements on the page during agent interactions
 - **Session History**: Persistent chat sessions stored locally
+- **Model Selector**: Choose which Copilot model to use directly from the panel header
 - **Dark/Light Mode**: Follows your system theme preference
 
 ## Getting Started
@@ -18,16 +19,18 @@ Your AI copilot for the web — a Chrome/Edge browser extension that brings GitH
 
 - Node.js 18+
 - Chrome or Edge browser
-- GitHub Copilot CLI (`@github/copilot`)
+- GitHub Copilot CLI (`@github/copilot`) — authenticated with a GitHub Copilot subscription
 
 ### Setup
 
 1. **Install dependencies**:
+
    ```bash
    npm install
    ```
 
 2. **Build the extension**:
+
    ```bash
    npm run build
    ```
@@ -39,6 +42,16 @@ Your AI copilot for the web — a Chrome/Edge browser extension that brings GitH
    - Select the `dist/` directory
 
 4. **Register the native messaging host**:
+
+   **Easy method** (recommended):
+
+   ```bash
+   # macOS/Linux - Interactive setup
+   ./scripts/setup-host.sh
+   ```
+
+   **Manual method**:
+
    ```bash
    # macOS/Linux
    scripts/register-host.sh <your-extension-id>
@@ -46,9 +59,89 @@ Your AI copilot for the web — a Chrome/Edge browser extension that brings GitH
    # Windows
    scripts\register-host.bat <your-extension-id>
    ```
+
    Your extension ID is shown on the extensions page after loading.
 
-5. **Restart your browser** and click the Copilot icon in the toolbar.
+5. **Restart your browser** completely (close all windows) and click the Copilot icon in the toolbar.
+
+---
+
+### WSL (Windows Subsystem for Linux)
+
+If you develop in WSL but run Chrome/Edge on Windows, native messaging requires a Windows-side wrapper because the browser can only launch Windows processes.
+
+**Architecture:**
+
+```text
+Chrome (Windows)
+    ↓ native messaging (stdio)
+wrapper.bat (Windows) — stdout/stdin pass-through, stderr → log file
+    ↓ wsl.exe
+host.mjs (WSL/Node.js)
+    ↓ JSON-RPC
+Copilot CLI (WSL)
+```
+
+**Steps:**
+
+1. **Build in WSL** as normal:
+
+   ```bash
+   npm install && npm run build
+   ```
+
+2. **Load the extension in Chrome** using the WSL UNC path:
+
+   ```text
+   \\wsl$\<distro>\home\<user>\path\to\github-copilot-browser\dist
+   ```
+
+   Copy the **Extension ID** shown on `chrome://extensions`.
+
+3. **Create a wrapper script on Windows** (e.g. `C:\copilot-host\wrapper.bat`):
+
+   ```bat
+   @echo off
+   wsl /usr/bin/node /home/<user>/path/to/github-copilot-browser/src/host/host.mjs 2>> "C:\Users\<user>\Documents\github.copilot.browser.log"
+   ```
+
+   Replace `/usr/bin/node` with the output of `which node` in WSL and adjust the path to `host.mjs`.
+
+   > ⚠️ **Critical**: Use `2>>` (stderr only) to redirect logs. **Never** redirect stdout (`>>`  or `2>&1`) — Chrome native messaging reads the length-prefixed JSON protocol from stdout, and any extra output will corrupt the connection.
+
+4. **Create the native messaging manifest on Windows** (`C:\copilot-host\com.github.copilot.browser.json`):
+
+   ```json
+   {
+     "name": "com.github.copilot.browser",
+     "description": "GitHub Copilot Browser Extension Native Messaging Host",
+     "path": "C:\\copilot-host\\wrapper.bat",
+     "type": "stdio",
+     "allowed_origins": [
+       "chrome-extension://<your-extension-id>/"
+     ]
+   }
+   ```
+
+5. **Register the manifest** in the Windows registry (run in PowerShell or CMD):
+
+   ```powershell
+   # Chrome
+   reg add "HKCU\Software\Google\Chrome\NativeMessagingHosts\com.github.copilot.browser" /ve /t REG_SZ /d "C:\copilot-host\com.github.copilot.browser.json" /f
+
+   # Edge (optional)
+   reg add "HKCU\Software\Microsoft\Edge\NativeMessagingHosts\com.github.copilot.browser" /ve /t REG_SZ /d "C:\copilot-host\com.github.copilot.browser.json" /f
+   ```
+
+6. **Restart Chrome** completely and open the extension.
+
+**Tail the log from WSL:**
+
+```bash
+tail -f "/mnt/c/Users/<user>/Documents/github.copilot.browser.log"
+```
+
+---
 
 ### Development
 
@@ -57,22 +150,82 @@ npm run dev    # Start Vite dev server with HMR
 npm run build  # Production build
 ```
 
+---
+
 ## Architecture
 
+```text
+Side Panel (React) ←→ Background Service Worker ←→ Native Messaging Host (Node.js) ←→ Copilot CLI (SDK)
+                              ↕
+                       Content Scripts (DOM access)
 ```
-Side Panel (React) ←→ Background Service Worker ←→ Native Messaging Host (Node.js) ←→ Copilot CLI
-                      ↕
-                   Content Scripts (DOM access)
-```
+
+### How custom tools work
+
+The native host (`host.mjs`) registers custom browser tools with the Copilot SDK using `defineTool`-compatible objects. When the LLM decides to call one:
+
+1. The Copilot CLI sends a `tool.call` JSON-RPC request to the SDK.
+2. The SDK calls the tool's `handler` function.
+3. The handler sends a `TOOL_CALL_REQUEST` message over native messaging to the background service worker.
+4. The service worker forwards it to the content script, which executes in the active tab.
+5. The result travels back through the same chain and is returned to the SDK / CLI / LLM.
+
+**Important:** `onPermissionRequest: approveAll` must be passed to `client.createSession()`. Without it the SDK returns `"denied"` for every tool call by default, silently preventing tool execution.
+
+Tool names use the prefix `github_copilot_browser__` to avoid conflicts with the CLI's own built-in tools (e.g. `execute_javascript`, `get_page_html`).
+
+---
 
 ## Tools
 
-The agent has access to 27+ tools across categories:
-- **Page Content**: get_page_content, get_page_html, get_page_structure, query_selector, get_page_tables, get_page_links, get_page_forms
-- **Visual**: capture_screenshot, highlight_element
-- **Interaction**: click_element, type_text, fill_form, select_option, scroll_page, press_key
-- **Navigation**: navigate_to, go_back, go_forward, open_tab, close_tab, switch_tab, reload_page
-- **Utility**: wait_for_element, execute_javascript
+The agent has access to 22 browser tools:
+
+| Category | Tools |
+|---|---|
+| **Page content** | `get_page_content`, `get_page_html`, `get_page_structure`, `query_selector`, `query_selector_all`, `get_page_tables`, `get_page_links`, `get_page_forms` |
+| **Visual** | `capture_screenshot`, `highlight_element` |
+| **Interaction** | `click_element`, `type_text`, `fill_form`, `scroll_page`, `execute_javascript` |
+| **Navigation** | `navigate_to`, `go_back`, `go_forward`, `open_tab`, `close_tab`, `get_open_tabs`, `reload_page` |
+
+---
+
+## Debugging
+
+### Check host logs (WSL setup)
+
+```bash
+tail -f "/mnt/c/Users/<user>/Documents/github.copilot.browser.log"
+```
+
+The log uses structured lines like:
+```
+[2025-01-01T00:00:00.000Z] [INFO ] Host process started, pid: 12345
+[2025-01-01T00:00:00.000Z] [INFO ] Found copilot via PATH: /usr/bin/copilot
+[2025-01-01T00:00:00.000Z] [INFO ] Host ready — session initialized
+[2025-01-01T00:00:00.000Z] [INFO ] Tool start: github_copilot_browser__get_page_content
+[2025-01-01T00:00:00.000Z] [INFO ] Tool handler called: github_copilot_browser__get_page_content
+```
+
+### Common issues
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Extension shows "Disconnected" | Native messaging host not registered | Run `setup-host.sh` or register manually |
+| Extension shows "Connecting…" but never connects | `wrapper.bat` stdout is being redirected (log output mixed with JSON protocol) | Change `>>` to `2>>` in wrapper.bat |
+| `ERR_MODULE_NOT_FOUND` for `@github/copilot-sdk` | Broken symlink in node_modules | Run `npm install` again |
+| Tools execute instantly with "permission denied" | Missing `onPermissionRequest: approveAll` | Already fixed in host.mjs — reload the extension |
+| Wrong page read (extension's own page instead of web page) | `getActiveTab()` using `currentWindow` when side panel has focus | Already fixed in tab-manager.ts |
+| Copilot CLI not found | CLI not in PATH in WSL | Set `COPILOT_CLI_PATH=/path/to/copilot` in wrapper.bat |
+
+### Set a custom CLI path in wrapper.bat
+
+```bat
+@echo off
+set COPILOT_CLI_PATH=/home/<user>/.npm-global/bin/copilot
+wsl /usr/bin/node /home/<user>/path/to/host.mjs 2>> "C:\Users\<user>\Documents\github.copilot.browser.log"
+```
+
+---
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,13 @@
       "name": "github-copilot-browser",
       "version": "0.1.0",
       "dependencies": {
-        "@github/copilot-sdk": "file:../copilot-sdk/nodejs",
+        "@github/copilot-sdk": "^0.1.25",
         "highlight.js": "^11.11.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^9.0.3",
-        "remark-gfm": "^4.0.0"
+        "remark-gfm": "^4.0.0",
+        "tsx": "^4.21.0"
       },
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.0.0-beta.28",
@@ -26,36 +27,6 @@
         "tailwindcss": "^4.1.0",
         "typescript": "^5.7.0",
         "vite": "^6.1.0"
-      }
-    },
-    "../copilot-sdk/nodejs": {
-      "name": "@github/copilot-sdk",
-      "version": "0.1.8",
-      "license": "MIT",
-      "dependencies": {
-        "@github/copilot": "^0.0.405",
-        "vscode-jsonrpc": "^8.2.1",
-        "zod": "^4.3.6"
-      },
-      "devDependencies": {
-        "@types/node": "^25.2.0",
-        "@typescript-eslint/eslint-plugin": "^8.54.0",
-        "@typescript-eslint/parser": "^8.54.0",
-        "esbuild": "^0.27.2",
-        "eslint": "^9.0.0",
-        "glob": "^13.0.1",
-        "json-schema": "^0.4.0",
-        "json-schema-to-typescript": "^15.0.4",
-        "prettier": "^3.8.1",
-        "quicktype-core": "^23.2.6",
-        "rimraf": "^6.1.2",
-        "semver": "^7.7.3",
-        "tsx": "^4.20.6",
-        "typescript": "^5.0.0",
-        "vitest": "^4.0.18"
-      },
-      "engines": {
-        "node": ">=24.0.0"
       }
     },
     "node_modules/@crxjs/vite-plugin": {
@@ -525,9 +496,132 @@
         "node": ">=18"
       }
     },
+    "node_modules/@github/copilot": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-0.0.414.tgz",
+      "integrity": "sha512-jseJ2S02CLWrFks5QK22zzq7as2ErY5m1wMCFBOE6sro1uACq1kvqqM1LwM4qy58YSZFrM1ZAn1s7UOVd9zhIA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "0.0.414",
+        "@github/copilot-darwin-x64": "0.0.414",
+        "@github/copilot-linux-arm64": "0.0.414",
+        "@github/copilot-linux-x64": "0.0.414",
+        "@github/copilot-win32-arm64": "0.0.414",
+        "@github/copilot-win32-x64": "0.0.414"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-0.0.414.tgz",
+      "integrity": "sha512-PW4v89v41i4Mg/NYl4+gEhwnDaVz+olNL+RbqtiQI3IV89gZdS+RZQbUEJfOwMaFcT2GfiUK1OuB+YDv5GrkBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-0.0.414.tgz",
+      "integrity": "sha512-NyPYm0NovQTwtuI42WJIi4cjYd2z0wBHEvWlUSczRsSuYEyImAClmZmBPegUU63e5JdZd1PdQkQ7FqrrfL2fZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-0.0.414.tgz",
+      "integrity": "sha512-VgdRsvA1FiZ1lcU/AscSvyJWEUWZzoXv2tSZ6WV3NE0uUTuO1Qoq4xuqbKZ/+vKJmn1b8afe7sxAAOtCoWPBHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-0.0.414.tgz",
+      "integrity": "sha512-3HyZsbZqYTF5jcT7/e+nDIYBCQXo8UCVWjBI3raOE4lzAw9b2ucL290IhtA23s1+EiquMxJ4m3FnjwFmwlQ12A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
     "node_modules/@github/copilot-sdk": {
-      "resolved": "../copilot-sdk/nodejs",
-      "link": true
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.1.26.tgz",
+      "integrity": "sha512-5YsApwYa/k2VqaNGvB+ngvWIRxyBR+AY17wCX3ceo+0UcwR7RbW0Ld8l8c5wFOh8Qa/UN4/kXb10HRUTYelGUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^0.0.414",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-0.0.414.tgz",
+      "integrity": "sha512-8gdaoF4MPpeV0h8UnCZ8TKI5l274EP0fvAaV9BGjsdyEydDcEb+DHqQiXgitWVKKiHAAaPi12aH8P5OsEDUneQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-0.0.414.tgz",
+      "integrity": "sha512-E1Oq1jXHaL1oWNsmmiCd4G30/CfgVdswg/T5oDFUxx3Ri+6uBekciIzdyCDelsP1kn2+fC1EYz2AerQ6F+huzg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -2015,7 +2109,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2024,6 +2117,18 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob-parent": {
@@ -3771,6 +3876,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -4005,6 +4119,482 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -4337,6 +4927,15 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -4359,6 +4958,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@github/copilot-sdk": "file:../copilot-sdk/nodejs",
+    "@github/copilot-sdk": "^0.1.25",
     "highlight.js": "^11.11.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^9.0.3",
-    "remark-gfm": "^4.0.0"
+    "remark-gfm": "^4.0.0",
+    "tsx": "^4.21.0"
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.28",

--- a/scripts/register-host.sh
+++ b/scripts/register-host.sh
@@ -5,7 +5,6 @@ HOST_NAME="com.github.copilot.browser"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 HOST_PATH="$PROJECT_DIR/src/host/host.mjs"
-MANIFEST_SOURCE="$PROJECT_DIR/src/host/$HOST_NAME.json"
 
 # Get extension ID from argument or prompt
 EXTENSION_ID="${1:-}"

--- a/scripts/setup-host.sh
+++ b/scripts/setup-host.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}═══════════════════════════════════════════════════════════${NC}"
+echo -e "${BLUE}  GitHub Copilot Browser - Native Host Setup${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════════════════${NC}"
+echo ""
+
+# Project paths
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+HOST_PATH="$PROJECT_DIR/src/host/host.mjs"
+HOST_NAME="com.github.copilot.browser"
+
+# Check if host.mjs exists and is executable
+if [ ! -f "$HOST_PATH" ]; then
+    echo -e "${RED}✗ Error: host.mjs not found at: $HOST_PATH${NC}"
+    exit 1
+fi
+
+if [ ! -x "$HOST_PATH" ]; then
+    echo -e "${YELLOW}⚠ Making host.mjs executable...${NC}"
+    chmod +x "$HOST_PATH"
+fi
+
+echo -e "${GREEN}✓ Host executable found${NC}"
+echo ""
+
+# Determine OS
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    CHROME_DIR="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+    EDGE_DIR="$HOME/Library/Application Support/Microsoft Edge/NativeMessagingHosts"
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    CHROME_DIR="$HOME/.config/google-chrome/NativeMessagingHosts"
+    EDGE_DIR="$HOME/.config/microsoft-edge/NativeMessagingHosts"
+else
+    echo -e "${RED}✗ Unsupported OS: $OSTYPE${NC}"
+    echo "For Windows, use register-host.bat instead."
+    exit 1
+fi
+
+# Check if already registered
+ALREADY_REGISTERED=false
+if [ -f "$CHROME_DIR/$HOST_NAME.json" ]; then
+    echo -e "${YELLOW}⚠ Host already registered in Chrome${NC}"
+    cat "$CHROME_DIR/$HOST_NAME.json"
+    echo ""
+    ALREADY_REGISTERED=true
+fi
+
+if [ -d "$EDGE_DIR" ] && [ -f "$EDGE_DIR/$HOST_NAME.json" ]; then
+    echo -e "${YELLOW}⚠ Host already registered in Edge${NC}"
+    cat "$EDGE_DIR/$HOST_NAME.json"
+    echo ""
+    ALREADY_REGISTERED=true
+fi
+
+if [ "$ALREADY_REGISTERED" = true ]; then
+    read -p "Do you want to re-register? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Skipping registration."
+        exit 0
+    fi
+fi
+
+# Get extension ID
+echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+echo -e "${YELLOW}Step 1: Get your Extension ID${NC}"
+echo ""
+echo "1. Open Chrome/Edge and go to: chrome://extensions"
+echo "2. Enable 'Developer mode' (top right)"
+echo "3. Find 'GitHub Copilot Browser' extension"
+echo "4. Copy the Extension ID (it looks like: abcdefghijklmnopqrstuvwxyz123456)"
+echo ""
+read -p "Enter your Extension ID: " EXTENSION_ID
+
+if [ -z "$EXTENSION_ID" ]; then
+    echo -e "${RED}✗ Extension ID cannot be empty${NC}"
+    exit 1
+fi
+
+# Validate extension ID format (32 lowercase letters)
+if ! [[ "$EXTENSION_ID" =~ ^[a-z]{32}$ ]]; then
+    echo -e "${YELLOW}⚠ Warning: Extension ID format looks unusual${NC}"
+    echo "Expected: 32 lowercase letters"
+    echo "Got: $EXTENSION_ID"
+    read -p "Continue anyway? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+echo ""
+echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+echo -e "${YELLOW}Step 2: Installing native messaging host${NC}"
+echo ""
+
+install_manifest() {
+    local target_dir="$1"
+    local browser_name="$2"
+    
+    mkdir -p "$target_dir"
+    
+    cat > "$target_dir/$HOST_NAME.json" <<EOF
+{
+  "name": "$HOST_NAME",
+  "description": "GitHub Copilot Browser Extension Native Messaging Host",
+  "path": "$HOST_PATH",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://$EXTENSION_ID/"
+  ]
+}
+EOF
+    
+    if [ -f "$target_dir/$HOST_NAME.json" ]; then
+        echo -e "${GREEN}✓ Registered for $browser_name${NC}"
+        echo "  Location: $target_dir/$HOST_NAME.json"
+    else
+        echo -e "${RED}✗ Failed to register for $browser_name${NC}"
+    fi
+}
+
+# Install for Chrome
+install_manifest "$CHROME_DIR" "Chrome"
+
+# Install for Edge if directory exists
+if [ -d "$(dirname "$EDGE_DIR")" ]; then
+    echo ""
+    read -p "Also register for Microsoft Edge? (y/n) " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        install_manifest "$EDGE_DIR" "Edge"
+    fi
+fi
+
+echo ""
+echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}✓ Setup Complete!${NC}"
+echo ""
+echo -e "${YELLOW}Next steps:${NC}"
+echo "1. Restart your browser completely (close all windows)"
+echo "2. Open the extension (click icon or press Ctrl+Shift+Y)"
+echo "3. Click 'Connect' in the header bar"
+echo ""
+echo -e "${YELLOW}Troubleshooting:${NC}"
+echo "• If connection fails, check browser console (F12)"
+echo "• Verify extension ID is correct"
+echo "• Make sure Node.js is installed: $(which node || echo 'NOT FOUND')"
+echo "• Check host logs with: journalctl --user -f | grep copilot"
+echo ""
+echo -e "${BLUE}════════════════════════════════════════════════════════════${NC}"

--- a/scripts/test-host.sh
+++ b/scripts/test-host.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Script to test the native messaging host locally
+
+HOST_PATH="$(dirname "$0")/../src/host/host.mjs"
+
+echo "Testing native messaging host..."
+echo ""
+echo "Host path: $HOST_PATH"
+echo "Node.js: $(which node)"
+echo "Node version: $(node --version)"
+echo ""
+
+# Check if host exists and is executable
+if [ ! -f "$HOST_PATH" ]; then
+    echo "❌ Error: host.mjs not found at $HOST_PATH"
+    exit 1
+fi
+
+if [ ! -x "$HOST_PATH" ]; then
+    echo "❌ Error: host.mjs is not executable"
+    exit 1
+fi
+
+echo "✓ Host file exists and is executable"
+echo ""
+
+# Check for @github/copilot-sdk
+if ! node -e "require('@github/copilot-sdk')" 2>/dev/null; then
+    echo "⚠️  Warning: @github/copilot-sdk not found"
+    echo "   Run: npm install"
+    echo ""
+fi
+
+echo "Testing host with a simple message..."
+echo '{"type":"SEND_CHAT_MESSAGE","payload":{"content":"test"}}' | \
+  node -e '
+    const msg = require("fs").readFileSync(0, "utf8");
+    const buf = Buffer.allocUnsafe(4 + Buffer.byteLength(msg));
+    buf.writeUInt32LE(Buffer.byteLength(msg), 0);
+    buf.write(msg, 4);
+    process.stdout.write(buf);
+  ' | timeout 5 "$HOST_PATH" 2>&1
+
+echo ""
+echo "If you see errors above, they will also appear in Chrome's native messaging logs."
+echo ""
+echo "To monitor logs in real-time on Windows:"
+echo "  PowerShell: Get-Content C:\\Users\\svg15\\Documents\\github.copilot.browser.log -Wait"
+echo "  CMD: type C:\\Users\\svg15\\Documents\\github.copilot.browser.log"

--- a/src/background/native-messaging.ts
+++ b/src/background/native-messaging.ts
@@ -1,17 +1,19 @@
 import { NATIVE_HOST_NAME } from '../shared/constants';
-import type { NativeMessage } from '../shared/messages';
+import type { HostInboundMessage, HostOutboundMessage } from '../shared/messages';
 import type { ConnectionStatus } from '../shared/types';
 
 type StatusListener = (status: ConnectionStatus) => void;
-type MessageListener = (message: NativeMessage) => void;
+type MessageListener = (message: HostInboundMessage) => void;
 
 class NativeMessagingClient {
   private port: chrome.runtime.Port | null = null;
   private statusListeners: StatusListener[] = [];
   private messageListeners: MessageListener[] = [];
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectDelay = 5000;
   private _status: ConnectionStatus = 'disconnected';
   private _lastError: string | null = null;
+  private _userDisconnected = false;
 
   get status(): ConnectionStatus {
     return this._status;
@@ -24,33 +26,49 @@ class NativeMessagingClient {
   connect(): void {
     if (this.port) return;
 
+    this._userDisconnected = false;
     this.setStatus('connecting');
 
     try {
       this.port = chrome.runtime.connectNative(NATIVE_HOST_NAME);
+      this._lastError = null;
 
-      this.port.onMessage.addListener((message: NativeMessage) => {
+      this.port.onMessage.addListener((message: HostInboundMessage) => {
         if (message.type === 'HOST_STATUS') {
-          this.setStatus(message.payload.connected ? 'connected' : 'error');
+          if (message.payload.connected) {
+            this.reconnectDelay = 5000; // reset backoff on success
+            this.setStatus('connected');
+          } else if (message.payload.status === 'initializing') {
+            this.setStatus('connecting');
+          } else {
+            this._lastError = message.payload.error || null;
+            this.setStatus('error');
+          }
         }
         this.messageListeners.forEach((listener) => listener(message));
       });
 
       this.port.onDisconnect.addListener(() => {
         const error = chrome.runtime.lastError?.message;
-        console.warn('[NativeMessaging] Disconnected:', error);
         this.port = null;
         this._lastError = error || null;
         this.setStatus('error');
+        // Auto-reconnect unless user explicitly disconnected
+        if (!this._userDisconnected) {
+          this.scheduleReconnect();
+        }
       });
     } catch (error) {
-      console.error('[NativeMessaging] Connection failed:', error);
+      this._lastError = error instanceof Error ? error.message : String(error);
       this.setStatus('error');
-      this.scheduleReconnect();
+      if (!this._userDisconnected) {
+        this.scheduleReconnect();
+      }
     }
   }
 
   disconnect(): void {
+    this._userDisconnected = true;
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -62,7 +80,7 @@ class NativeMessagingClient {
     this.setStatus('disconnected');
   }
 
-  send(message: NativeMessage): void {
+  send(message: HostOutboundMessage): void {
     if (!this.port) {
       throw new Error('Not connected to native host');
     }
@@ -92,9 +110,11 @@ class NativeMessagingClient {
     if (this.reconnectTimer) return;
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
+      this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000); // exponential backoff, max 30s
       this.connect();
-    }, 5000);
+    }, this.reconnectDelay);
   }
 }
 
 export const nativeMessaging = new NativeMessagingClient();
+

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -78,6 +78,14 @@ async function handlePanelMessage(message: PanelMessage, port: chrome.runtime.Po
 
     case 'EXECUTE_TOOL':
       break;
+
+    case 'GET_MODELS':
+      nativeMessaging.send({ type: 'GET_MODELS' });
+      break;
+
+    case 'SET_MODEL':
+      nativeMessaging.send({ type: 'SET_MODEL', payload: { model: message.payload.model } });
+      break;
   }
 }
 
@@ -89,6 +97,8 @@ nativeMessaging.onMessage((message: any) => {
   switch (message.type) {
     // Full assistant response
     case 'CHAT_RESPONSE':
+      // Skip empty responses (occur when the LLM calls tools without a text message)
+      if (!message.payload.content) break;
       sendToPanels({
         type: 'CHAT_RESPONSE_COMPLETE',
         payload: {
@@ -122,6 +132,8 @@ nativeMessaging.onMessage((message: any) => {
     // Host requests a browser tool execution (LLM called a tool)
     case 'TOOL_CALL_REQUEST': {
       const { toolCallId, toolName, arguments: args } = message.payload;
+      // Strip repo prefix (github_copilot_browser__) added to avoid conflicts with CLI built-in tools
+      const registryToolName = toolName.replace(/^github_copilot_browser__/, '');
 
       sendToPanels({
         type: 'TOOL_CALL_START',
@@ -132,7 +144,8 @@ nativeMessaging.onMessage((message: any) => {
       });
 
       // Execute the tool in the extension
-      executeTool(toolName, args || {}).then((result) => {
+      executeTool(registryToolName, args || {}).then((result) => {
+        // DEBUG console.log('[Background] Tool result:', registryToolName, JSON.stringify(result).slice(0, 200));
         // Send result back to the native host so the SDK can feed it to the LLM
         nativeMessaging.send({
           type: 'TOOL_CALL_RESULT',
@@ -143,6 +156,12 @@ nativeMessaging.onMessage((message: any) => {
           type: 'TOOL_CALL_RESULT',
           payload: { toolCallId, result, sessionId },
         });
+      }).catch((error) => {
+        console.error('[Background] Tool execution error:', registryToolName, error.message);
+        nativeMessaging.send({
+          type: 'TOOL_CALL_RESULT',
+          payload: { toolCallId, result: { success: false, error: error.message } },
+        });
       });
       break;
     }
@@ -151,6 +170,11 @@ nativeMessaging.onMessage((message: any) => {
     case 'TOOL_EXECUTION_START':
     case 'TOOL_EXECUTION_COMPLETE':
       // Already handled via TOOL_CALL_REQUEST flow
+      break;
+
+    // Available models list from host
+    case 'MODELS_LIST':
+      sendToPanels({ type: 'MODELS_LIST', payload: message.payload });
       break;
   }
 });

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -1,10 +1,9 @@
 import { nativeMessaging } from './native-messaging';
 import { executeTool } from './tools-registry';
 import * as tabManager from './tab-manager';
+import * as sessionStorage from '../panel/lib/session-storage';
 import type { PanelMessage, BackgroundMessage } from '../shared/messages';
 import type { ConnectionStatus } from '../shared/types';
-
-console.log('[Background] Service worker loaded');
 
 // Track panel connections
 const panelPorts: chrome.runtime.Port[] = [];
@@ -85,18 +84,18 @@ async function handlePanelMessage(message: PanelMessage, port: chrome.runtime.Po
     }
 
     case 'CANCEL_REQUEST':
-      nativeMessaging.send({ type: 'CANCEL_REQUEST' });
+      try { nativeMessaging.send({ type: 'CANCEL_REQUEST' }); } catch { /* not connected */ }
       break;
 
     case 'EXECUTE_TOOL':
       break;
 
     case 'GET_MODELS':
-      nativeMessaging.send({ type: 'GET_MODELS' });
+      try { nativeMessaging.send({ type: 'GET_MODELS' }); } catch { /* not connected */ }
       break;
 
     case 'SET_MODEL':
-      nativeMessaging.send({ type: 'SET_MODEL', payload: { model: message.payload.model } });
+      try { nativeMessaging.send({ type: 'SET_MODEL', payload: { model: message.payload.model } }); } catch { /* not connected */ }
       break;
   }
 }
@@ -107,18 +106,22 @@ nativeMessaging.onMessage((message: any) => {
     case 'CHAT_RESPONSE':
       // Skip empty responses (occur when the LLM calls tools without a text message)
       if (!message.payload.content) break;
-      sendToActivePanel({
-        type: 'CHAT_RESPONSE_COMPLETE',
-        payload: {
-          message: {
-            id: crypto.randomUUID(),
-            role: 'assistant',
-            content: message.payload.content,
-            timestamp: Date.now(),
-          },
-          sessionId: activeSessionId,
-        },
-      });
+      {
+        const assistantMsg = {
+          id: crypto.randomUUID(),
+          role: 'assistant' as const,
+          content: message.payload.content,
+          timestamp: Date.now(),
+        };
+        sendToActivePanel({
+          type: 'CHAT_RESPONSE_COMPLETE',
+          payload: { message: assistantMsg, sessionId: activeSessionId },
+        });
+        // Persist assistant message to session storage
+        if (activeSessionId) {
+          sessionStorage.addMessage(activeSessionId, assistantMsg).catch(() => {});
+        }
+      }
       break;
 
     // Streaming chunk

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -9,6 +9,10 @@ console.log('[Background] Service worker loaded');
 // Track panel connections
 const panelPorts: chrome.runtime.Port[] = [];
 
+// Track which panel initiated the current request (receives responses/tool calls)
+let activePort: chrome.runtime.Port | null = null;
+let activeSessionId: string = 'current';
+
 // Listen for connections from the side panel
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name === 'copilot-panel') {
@@ -22,6 +26,7 @@ chrome.runtime.onConnect.addListener((port) => {
     port.onDisconnect.addListener(() => {
       const index = panelPorts.indexOf(port);
       if (index > -1) panelPorts.splice(index, 1);
+      if (activePort === port) activePort = null;
       console.log('[Background] Panel disconnected');
     });
 
@@ -59,6 +64,9 @@ async function handlePanelMessage(message: PanelMessage, port: chrome.runtime.Po
 
     case 'SEND_CHAT_MESSAGE': {
       const { content, sessionId } = message.payload;
+      // Bind this panel as the active recipient for the response
+      activePort = port;
+      activeSessionId = sessionId;
       try {
         nativeMessaging.send({
           type: 'SEND_CHAT_MESSAGE',
@@ -76,6 +84,10 @@ async function handlePanelMessage(message: PanelMessage, port: chrome.runtime.Po
       break;
     }
 
+    case 'CANCEL_REQUEST':
+      nativeMessaging.send({ type: 'CANCEL_REQUEST' });
+      break;
+
     case 'EXECUTE_TOOL':
       break;
 
@@ -89,17 +101,13 @@ async function handlePanelMessage(message: PanelMessage, port: chrome.runtime.Po
   }
 }
 
-// Forward native messaging responses from host to panels
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 nativeMessaging.onMessage((message: any) => {
-  const sessionId = 'current';
-
   switch (message.type) {
     // Full assistant response
     case 'CHAT_RESPONSE':
       // Skip empty responses (occur when the LLM calls tools without a text message)
       if (!message.payload.content) break;
-      sendToPanels({
+      sendToActivePanel({
         type: 'CHAT_RESPONSE_COMPLETE',
         payload: {
           message: {
@@ -108,24 +116,24 @@ nativeMessaging.onMessage((message: any) => {
             content: message.payload.content,
             timestamp: Date.now(),
           },
-          sessionId,
+          sessionId: activeSessionId,
         },
       });
       break;
 
     // Streaming chunk
     case 'CHAT_RESPONSE_CHUNK':
-      sendToPanels({
+      sendToActivePanel({
         type: 'CHAT_RESPONSE_CHUNK',
-        payload: { chunk: message.payload.content, sessionId },
+        payload: { chunk: message.payload.content, sessionId: activeSessionId },
       });
       break;
 
     // Chat error
     case 'CHAT_RESPONSE_ERROR':
-      sendToPanels({
+      sendToActivePanel({
         type: 'CHAT_RESPONSE_ERROR',
-        payload: { error: message.payload.error, sessionId },
+        payload: { error: message.payload.error, sessionId: activeSessionId },
       });
       break;
 
@@ -135,26 +143,25 @@ nativeMessaging.onMessage((message: any) => {
       // Strip repo prefix (github_copilot_browser__) added to avoid conflicts with CLI built-in tools
       const registryToolName = toolName.replace(/^github_copilot_browser__/, '');
 
-      sendToPanels({
+      sendToActivePanel({
         type: 'TOOL_CALL_START',
         payload: {
           toolCall: { id: toolCallId, name: toolName, parameters: args || {}, status: 'running' },
-          sessionId,
+          sessionId: activeSessionId,
         },
       });
 
       // Execute the tool in the extension
       executeTool(registryToolName, args || {}).then((result) => {
-        // DEBUG console.log('[Background] Tool result:', registryToolName, JSON.stringify(result).slice(0, 200));
         // Send result back to the native host so the SDK can feed it to the LLM
         nativeMessaging.send({
           type: 'TOOL_CALL_RESULT',
           payload: { toolCallId, result },
         });
 
-        sendToPanels({
+        sendToActivePanel({
           type: 'TOOL_CALL_RESULT',
-          payload: { toolCallId, result, sessionId },
+          payload: { toolCallId, result, sessionId: activeSessionId },
         });
       }).catch((error) => {
         console.error('[Background] Tool execution error:', registryToolName, error.message);
@@ -172,7 +179,7 @@ nativeMessaging.onMessage((message: any) => {
       // Already handled via TOOL_CALL_REQUEST flow
       break;
 
-    // Available models list from host
+    // Broadcast to all panels (not session-specific)
     case 'MODELS_LIST':
       sendToPanels({ type: 'MODELS_LIST', payload: message.payload });
       break;
@@ -204,6 +211,10 @@ chrome.runtime.onMessage.addListener((message, sender) => {
 // Helper functions
 function sendToPanel(port: chrome.runtime.Port, message: BackgroundMessage): void {
   port.postMessage(message);
+}
+
+function sendToActivePanel(message: BackgroundMessage): void {
+  if (activePort) sendToPanel(activePort, message);
 }
 
 function sendToPanels(message: BackgroundMessage): void {

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -13,8 +13,21 @@ export async function getOpenTabs(): Promise<TabInfo[]> {
 }
 
 export async function getActiveTab(): Promise<chrome.tabs.Tab | null> {
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  return tab || null;
+  // Try lastFocusedWindow first — works correctly when side panel has focus
+  const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+  if (tab) {
+    console.log('[TabManager] Active tab:', tab.id, tab.url);
+    // Skip chrome-extension:// and chrome:// — content scripts can't run there
+    if (tab.url && !tab.url.startsWith('chrome-extension://') && !tab.url.startsWith('chrome://') && !tab.url.startsWith('edge://')) {
+      return tab;
+    }
+    console.warn('[TabManager] Active tab is restricted URL, searching for real tab:', tab.url);
+  }
+  // Fallback: find a real active tab across all windows
+  const allActive = await chrome.tabs.query({ active: true });
+  const realTab = allActive.find(t => t.url && !t.url.startsWith('chrome-extension://') && !t.url.startsWith('chrome://') && !t.url.startsWith('edge://')) || null;
+  console.log('[TabManager] Fallback tab:', realTab?.id, realTab?.url);
+  return realTab;
 }
 
 export async function navigateTo(url: string, tabId?: number): Promise<void> {

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -16,18 +16,14 @@ export async function getActiveTab(): Promise<chrome.tabs.Tab | null> {
   // Try lastFocusedWindow first — works correctly when side panel has focus
   const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
   if (tab) {
-    console.log('[TabManager] Active tab:', tab.id, tab.url);
     // Skip chrome-extension:// and chrome:// — content scripts can't run there
     if (tab.url && !tab.url.startsWith('chrome-extension://') && !tab.url.startsWith('chrome://') && !tab.url.startsWith('edge://')) {
       return tab;
     }
-    console.warn('[TabManager] Active tab is restricted URL, searching for real tab:', tab.url);
   }
   // Fallback: find a real active tab across all windows
   const allActive = await chrome.tabs.query({ active: true });
-  const realTab = allActive.find(t => t.url && !t.url.startsWith('chrome-extension://') && !t.url.startsWith('chrome://') && !t.url.startsWith('edge://')) || null;
-  console.log('[TabManager] Fallback tab:', realTab?.id, realTab?.url);
-  return realTab;
+  return allActive.find(t => t.url && !t.url.startsWith('chrome-extension://') && !t.url.startsWith('chrome://') && !t.url.startsWith('edge://')) || null;
 }
 
 export async function navigateTo(url: string, tabId?: number): Promise<void> {

--- a/src/host/com.github.copilot.browser.json
+++ b/src/host/com.github.copilot.browser.json
@@ -1,9 +1,0 @@
-{
-  "name": "com.github.copilot.browser",
-  "description": "GitHub Copilot Browser Extension Native Messaging Host",
-  "path": "/PLACEHOLDER/src/host/host.mjs",
-  "type": "stdio",
-  "allowed_origins": [
-    "chrome-extension://EXTENSION_ID_HERE/"
-  ]
-}

--- a/src/host/host.mjs
+++ b/src/host/host.mjs
@@ -321,6 +321,14 @@ async function handleMessage(message) {
       break;
     }
 
+    case 'CANCEL_REQUEST': {
+      if (session) {
+        log.info('Aborting current session request');
+        session.abort().catch((e) => log.warn('abort() failed:', e.message));
+      }
+      break;
+    }
+
     case 'TOOL_CALL_RESULT': {
       const { toolCallId, result } = message.payload;
       const pending = pendingToolCalls.get(toolCallId);

--- a/src/host/host.mjs
+++ b/src/host/host.mjs
@@ -108,6 +108,8 @@ function readMessages(callback) {
 let client = null;
 let session = null;
 let currentModel = undefined; // undefined = CLI default
+let isGenerating = false;    // true while session.send() is in progress
+let streamedContent = '';    // accumulates CHAT_RESPONSE_CHUNK content during a response
 
 // Pending tool call requests from the extension (browser tools)
 // When the LLM calls a browser tool, we forward it to the extension
@@ -233,12 +235,17 @@ async function createNewSession() {
     log.debug('Session event:', event.type, JSON.stringify(event.data || {}).slice(0, 300));
     switch (event.type) {
       case 'assistant.message':
+        if (!isGenerating) break; // post-abort, ignore
+        isGenerating = false;
+        streamedContent = '';
         sendMessage({
           type: 'CHAT_RESPONSE',
           payload: { content: event.data.content, done: true },
         });
         break;
       case 'assistant.message_delta':
+        if (!isGenerating) break; // post-abort, ignore
+        streamedContent += event.data.content || '';
         sendMessage({
           type: 'CHAT_RESPONSE_CHUNK',
           payload: { content: event.data.content },
@@ -313,18 +320,29 @@ async function handleMessage(message) {
         sendMessage({ type: 'CHAT_RESPONSE_ERROR', payload: { error: 'Session not initialized' } });
         return;
       }
+      isGenerating = true;
+      streamedContent = '';
       try {
         await session.send({ prompt: message.payload.content });
       } catch (error) {
+        isGenerating = false;
+        streamedContent = '';
         sendMessage({ type: 'CHAT_RESPONSE_ERROR', payload: { error: error.message } });
       }
       break;
     }
 
     case 'CANCEL_REQUEST': {
-      if (session) {
+      if (session && isGenerating) {
         log.info('Aborting current session request');
+        const partialContent = streamedContent;
+        isGenerating = false;
+        streamedContent = '';
         session.abort().catch((e) => log.warn('abort() failed:', e.message));
+        // Send whatever was streamed so far as a complete response
+        if (partialContent) {
+          sendMessage({ type: 'CHAT_RESPONSE', payload: { content: partialContent, done: true } });
+        }
       }
       break;
     }
@@ -368,6 +386,8 @@ async function handleMessage(message) {
       const { model } = message.payload;
       log.info('Changing model to:', model);
       currentModel = model;
+      isGenerating = false;
+      streamedContent = '';
       try {
         await createNewSession();
         sendMessage({ type: 'HOST_STATUS', payload: { connected: true } });

--- a/src/host/host.mjs
+++ b/src/host/host.mjs
@@ -1,5 +1,69 @@
-#!/opt/homebrew/bin/node
-import { CopilotClient } from '@github/copilot-sdk';
+#!/usr/bin/env node
+import { CopilotClient, approveAll } from '@github/copilot-sdk';
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+// ── CLI path resolution ──────────────────────────────────────────────
+function findCopilotCli() {
+  const isWindows = process.platform === 'win32';
+
+  // 1. Explicit override via env var
+  if (process.env.COPILOT_CLI_PATH) {
+    log.info('COPILOT_CLI_PATH set:', process.env.COPILOT_CLI_PATH);
+    if (existsSync(process.env.COPILOT_CLI_PATH)) return process.env.COPILOT_CLI_PATH;
+    log.warn('COPILOT_CLI_PATH does not exist:', process.env.COPILOT_CLI_PATH);
+  }
+
+  // 2. Search PATH using `which` / `where`
+  try {
+    const cmd = isWindows ? 'where copilot' : 'which copilot';
+    const result = execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim().split('\n')[0].trim();
+    if (result && existsSync(result)) {
+      log.info('Found copilot via PATH:', result);
+      return result;
+    }
+  } catch {}
+
+  // 3. Common install locations
+  const candidates = isWindows
+    ? [
+        join(process.env.APPDATA || '', 'npm', 'copilot.cmd'),
+        join(process.env.LOCALAPPDATA || '', 'npm', 'copilot.cmd'),
+        'C:\\Program Files\\nodejs\\copilot.cmd',
+      ]
+    : [
+        '/opt/homebrew/bin/copilot',
+        '/usr/local/bin/copilot',
+        '/usr/bin/copilot',
+        join(process.env.HOME || '', '.npm-global', 'bin', 'copilot'),
+        join(process.env.HOME || '', '.local', 'bin', 'copilot'),
+      ];
+
+  for (const p of candidates) {
+    log.debug('Checking:', p);
+    if (existsSync(p)) {
+      log.info('Found copilot at:', p);
+      return p;
+    }
+  }
+
+  log.error('Copilot CLI not found. Searched:', candidates.join(', '));
+  log.error('Set COPILOT_CLI_PATH env var to override.');
+  return null;
+}
+
+// ── Logger (stderr only — stdout is reserved for native messaging) ───
+const log = {
+  _write(level, ...args) {
+    const ts = new Date().toISOString();
+    process.stderr.write(`[${ts}] [${level}] ${args.map(a => typeof a === 'object' ? JSON.stringify(a) : a).join(' ')}\n`);
+  },
+  info:  (...a) => log._write('INFO ', ...a),
+  warn:  (...a) => log._write('WARN ', ...a),
+  error: (...a) => log._write('ERROR', ...a),
+  debug: (...a) => log._write('DEBUG', ...a),
+};
 
 // ── Chrome Native Messaging Protocol ────────────────────────────────
 // 4-byte little-endian length prefix + JSON payload on stdin/stdout.
@@ -8,6 +72,7 @@ import { CopilotClient } from '@github/copilot-sdk';
 let buffer = Buffer.alloc(0);
 
 function sendMessage(message) {
+  log.debug('→ Chrome:', message.type, message.payload || '');
   const json = JSON.stringify(message);
   const buf = Buffer.alloc(4 + Buffer.byteLength(json, 'utf8'));
   buf.writeUInt32LE(Buffer.byteLength(json, 'utf8'), 0);
@@ -26,8 +91,11 @@ function readMessages(callback) {
         const data = buffer.subarray(4, 4 + len);
         buffer = buffer.subarray(4 + len);
         try {
-          callback(JSON.parse(data.toString('utf8')));
+          const msg = JSON.parse(data.toString('utf8'));
+          log.debug('← Chrome:', msg.type, msg.payload || '');
+          callback(msg);
         } catch (e) {
+          log.error('Parse error:', e.message);
           sendMessage({ type: 'HOST_STATUS', payload: { connected: false, error: `Parse error: ${e.message}` } });
         }
       }
@@ -39,6 +107,7 @@ function readMessages(callback) {
 
 let client = null;
 let session = null;
+let currentModel = undefined; // undefined = CLI default
 
 // Pending tool call requests from the extension (browser tools)
 // When the LLM calls a browser tool, we forward it to the extension
@@ -52,131 +121,187 @@ function makeBrowserTool(name, description, parameters) {
     description,
     parameters: parameters || {},
     handler: async (args, invocation) => {
+      log.info(`Tool handler called: ${name} | callId: ${invocation?.toolCallId}`);
       // Forward tool call to extension and wait for result
       return new Promise((resolve, reject) => {
-        const callId = invocation.toolCallId;
-        pendingToolCalls.set(callId, { resolve, reject });
-
-        sendMessage({
-          type: 'TOOL_CALL_REQUEST',
-          payload: { toolCallId: callId, toolName: name, arguments: args },
-        });
-
-        // Timeout after 30s
-        setTimeout(() => {
-          if (pendingToolCalls.has(callId)) {
-            pendingToolCalls.delete(callId);
-            resolve(`Tool ${name} timed out after 30 seconds`);
+        try {
+          const callId = invocation?.toolCallId;
+          if (!callId) {
+            log.error(`No toolCallId in invocation for tool: ${name}`, invocation);
+            return resolve(`Error: missing toolCallId`);
           }
-        }, 30000);
+          pendingToolCalls.set(callId, { resolve, reject });
+          log.info(`Sending TOOL_CALL_REQUEST: ${name} callId: ${callId}`);
+          sendMessage({
+            type: 'TOOL_CALL_REQUEST',
+            payload: { toolCallId: callId, toolName: name, arguments: args },
+          });
+          log.info(`TOOL_CALL_REQUEST sent, waiting for result...`);
+
+          // Timeout after 30s
+          setTimeout(() => {
+            if (pendingToolCalls.has(callId)) {
+              log.warn(`Tool timed out after 30s: ${name} callId: ${callId}`);
+              pendingToolCalls.delete(callId);
+              resolve(`Tool ${name} timed out after 30 seconds`);
+            }
+          }, 30000);
+        } catch (err) {
+          log.error(`Handler exception in ${name}:`, err.message, err.stack);
+          reject(err);
+        }
       });
     },
   };
 }
 
+const TOOL_PREFIX = 'github_copilot_browser__';
+
 const browserTools = [
-  makeBrowserTool('get_page_content', 'Extract full text content, title, URL from the active browser tab'),
-  makeBrowserTool('get_page_html', 'Get raw HTML of the page or a CSS-selector-scoped subtree', {
+  makeBrowserTool(`${TOOL_PREFIX}get_page_content`, 'Extract full text content, title, URL from the active browser tab'),
+  makeBrowserTool(`${TOOL_PREFIX}get_page_html`, 'Get raw HTML of the page or a CSS-selector-scoped subtree', {
     type: 'object', properties: { selector: { type: 'string', description: 'Optional CSS selector' } },
   }),
-  makeBrowserTool('get_page_structure', 'Get semantic outline: headings, landmarks, forms, tables from the active tab'),
-  makeBrowserTool('query_selector', 'Find first element matching a CSS selector in the active tab', {
+  makeBrowserTool(`${TOOL_PREFIX}get_page_structure`, 'Get semantic outline: headings, landmarks, forms, tables from the active tab'),
+  makeBrowserTool(`${TOOL_PREFIX}query_selector`, 'Find first element matching a CSS selector in the active tab', {
     type: 'object', properties: { selector: { type: 'string', description: 'CSS selector' } }, required: ['selector'],
   }),
-  makeBrowserTool('query_selector_all', 'Find all elements matching a CSS selector', {
+  makeBrowserTool(`${TOOL_PREFIX}query_selector_all`, 'Find all elements matching a CSS selector', {
     type: 'object', properties: { selector: { type: 'string', description: 'CSS selector' } }, required: ['selector'],
   }),
-  makeBrowserTool('get_page_tables', 'Extract all tables as structured JSON from the active tab'),
-  makeBrowserTool('get_page_links', 'Extract all links with text and href from the active tab'),
-  makeBrowserTool('get_page_forms', 'Extract form fields with labels, types, and values from the active tab'),
-  makeBrowserTool('capture_screenshot', 'Capture screenshot of the visible browser viewport (returns base64 PNG)'),
-  makeBrowserTool('highlight_element', 'Temporarily highlight an element on the page', {
+  makeBrowserTool(`${TOOL_PREFIX}get_page_tables`, 'Extract all tables as structured JSON from the active tab'),
+  makeBrowserTool(`${TOOL_PREFIX}get_page_links`, 'Extract all links with text and href from the active tab'),
+  makeBrowserTool(`${TOOL_PREFIX}get_page_forms`, 'Extract form fields with labels, types, and values from the active tab'),
+  makeBrowserTool(`${TOOL_PREFIX}capture_screenshot`, 'Capture screenshot of the visible browser viewport (returns base64 PNG)'),
+  makeBrowserTool(`${TOOL_PREFIX}highlight_element`, 'Temporarily highlight an element on the page', {
     type: 'object', properties: { selector: { type: 'string' }, color: { type: 'string' } }, required: ['selector'],
   }),
-  makeBrowserTool('click_element', 'Click an element by CSS selector in the active tab', {
+  makeBrowserTool(`${TOOL_PREFIX}click_element`, 'Click an element by CSS selector in the active tab', {
     type: 'object', properties: { selector: { type: 'string', description: 'CSS selector' } }, required: ['selector'],
   }),
-  makeBrowserTool('type_text', 'Type text into an input field in the active tab', {
+  makeBrowserTool(`${TOOL_PREFIX}type_text`, 'Type text into an input field in the active tab', {
     type: 'object', properties: { selector: { type: 'string' }, text: { type: 'string' } }, required: ['selector', 'text'],
   }),
-  makeBrowserTool('fill_form', 'Fill multiple form fields at once', {
+  makeBrowserTool(`${TOOL_PREFIX}fill_form`, 'Fill multiple form fields at once', {
     type: 'object', properties: { fields: { type: 'object', description: 'Map of selector to value' } }, required: ['fields'],
   }),
-  makeBrowserTool('scroll_page', 'Scroll the page', {
+  makeBrowserTool(`${TOOL_PREFIX}scroll_page`, 'Scroll the page', {
     type: 'object', properties: { direction: { type: 'string' }, amount: { type: 'number' }, selector: { type: 'string' } },
   }),
-  makeBrowserTool('navigate_to', 'Navigate the active browser tab to a URL', {
+  makeBrowserTool(`${TOOL_PREFIX}navigate_to`, 'Navigate the active browser tab to a URL', {
     type: 'object', properties: { url: { type: 'string', description: 'URL to navigate to' } }, required: ['url'],
   }),
-  makeBrowserTool('open_tab', 'Open a new browser tab', {
+  makeBrowserTool(`${TOOL_PREFIX}open_tab`, 'Open a new browser tab', {
     type: 'object', properties: { url: { type: 'string' } }, required: ['url'],
   }),
-  makeBrowserTool('close_tab', 'Close a browser tab', {
+  makeBrowserTool(`${TOOL_PREFIX}close_tab`, 'Close a browser tab', {
     type: 'object', properties: { tabId: { type: 'number' } }, required: ['tabId'],
   }),
-  makeBrowserTool('get_open_tabs', 'List all open browser tabs with titles and URLs'),
-  makeBrowserTool('go_back', 'Go back in browser history'),
-  makeBrowserTool('go_forward', 'Go forward in browser history'),
-  makeBrowserTool('reload_page', 'Reload the current browser page'),
-  makeBrowserTool('execute_javascript', 'Run JavaScript in the active tab page context', {
+  makeBrowserTool(`${TOOL_PREFIX}get_open_tabs`, 'List all open browser tabs with titles and URLs'),
+  makeBrowserTool(`${TOOL_PREFIX}go_back`, 'Go back in browser history'),
+  makeBrowserTool(`${TOOL_PREFIX}go_forward`, 'Go forward in browser history'),
+  makeBrowserTool(`${TOOL_PREFIX}reload_page`, 'Reload the current browser page'),
+  makeBrowserTool(`${TOOL_PREFIX}execute_javascript`, 'Run JavaScript in the active tab page context', {
     type: 'object', properties: { code: { type: 'string', description: 'JavaScript code to execute' } }, required: ['code'],
   }),
 ];
 
-async function initialize() {
-  try {
-    client = new CopilotClient({
-      cliPath: '/opt/homebrew/bin/copilot',
-      logLevel: 'error',
-      env: { ...process.env, PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH || '/usr/bin:/bin'}` },
-    });
+async function createNewSession() {
+  if (session) {
+    await session.destroy().catch(() => {});
+    session = null;
+  }
+  log.info('Creating session...', currentModel ? `model: ${currentModel}` : 'default model');
+  session = await client.createSession({
+    ...(currentModel ? { model: currentModel } : {}),
+    tools: browserTools,
+    onPermissionRequest: approveAll,
+    systemMessage: {
+      mode: 'append',
+      content: [
+        'You are a browser assistant embedded in a Chrome/Edge extension.',
+        `You can see and interact with web pages using tools prefixed with "${TOOL_PREFIX}".`,
+        `Use ${TOOL_PREFIX}get_page_content or ${TOOL_PREFIX}capture_screenshot to read the current page.`,
+        `Use ${TOOL_PREFIX}click_element, ${TOOL_PREFIX}type_text, ${TOOL_PREFIX}fill_form for interactions.`,
+        `Use ${TOOL_PREFIX}navigate_to, ${TOOL_PREFIX}open_tab, ${TOOL_PREFIX}get_open_tabs for navigation.`,
+        'Always confirm destructive actions before executing them.',
+      ].join('\n'),
+    },
+  });
 
-    session = await client.createSession({
-      tools: browserTools,
-      systemMessage: {
-        mode: 'append',
-        content: [
-          'You are a browser assistant embedded in a Chrome/Edge extension.',
-          'You can see and interact with web pages using the browser tools provided.',
-          'When the user asks about page content, use get_page_content or capture_screenshot first.',
-          'For interactions (clicking, typing, filling forms), use the appropriate tool.',
-          'Always confirm destructive actions before executing them.',
-        ].join('\n'),
+  session.on((event) => {
+    log.debug('Session event:', event.type, JSON.stringify(event.data || {}).slice(0, 300));
+    switch (event.type) {
+      case 'assistant.message':
+        sendMessage({
+          type: 'CHAT_RESPONSE',
+          payload: { content: event.data.content, done: true },
+        });
+        break;
+      case 'assistant.message_delta':
+        sendMessage({
+          type: 'CHAT_RESPONSE_CHUNK',
+          payload: { content: event.data.content },
+        });
+        break;
+      case 'tool.execution_start':
+        log.info('Tool start:', event.data.toolName, event.data.toolCallId);
+        sendMessage({
+          type: 'TOOL_EXECUTION_START',
+          payload: { toolCallId: event.data.toolCallId, toolName: event.data.toolName },
+        });
+        break;
+      case 'tool.execution_complete':
+        log.info('Tool done:', event.data.toolName, event.data.toolCallId);
+        sendMessage({
+          type: 'TOOL_EXECUTION_COMPLETE',
+          payload: { toolCallId: event.data.toolCallId, toolName: event.data.toolName },
+        });
+        break;
+    }
+  });
+}
+
+async function initialize() {
+  log.info('Starting host — platform:', process.platform, 'node:', process.version);
+  log.info('Working directory:', process.cwd());
+
+  const cliPath = findCopilotCli();
+  if (!cliPath) {
+    sendMessage({
+      type: 'HOST_STATUS',
+      payload: {
+        connected: false,
+        error: 'Copilot CLI not found. Install it with: npm install -g @github/copilot\nOr set the COPILOT_CLI_PATH environment variable.',
       },
     });
+    return;
+  }
 
-    // Listen for session events and forward to extension
-    session.on((event) => {
-      switch (event.type) {
-        case 'assistant.message':
-          sendMessage({
-            type: 'CHAT_RESPONSE',
-            payload: { content: event.data.content, done: true },
-          });
-          break;
-        case 'assistant.message_delta':
-          sendMessage({
-            type: 'CHAT_RESPONSE_CHUNK',
-            payload: { content: event.data.content },
-          });
-          break;
-        case 'tool.execution_start':
-          sendMessage({
-            type: 'TOOL_EXECUTION_START',
-            payload: { toolCallId: event.data.toolCallId, toolName: event.data.toolName },
-          });
-          break;
-        case 'tool.execution_complete':
-          sendMessage({
-            type: 'TOOL_EXECUTION_COMPLETE',
-            payload: { toolCallId: event.data.toolCallId, toolName: event.data.toolName },
-          });
-          break;
-      }
+  log.info('Using Copilot CLI:', cliPath);
+
+  // Build a resilient PATH that includes common binary dirs for this OS
+  const isWindows = process.platform === 'win32';
+  const extraPaths = isWindows
+    ? [join(process.env.APPDATA || '', 'npm'), join(process.env.LOCALAPPDATA || '', 'npm')]
+    : ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin', join(process.env.HOME || '', '.npm-global', 'bin'), join(process.env.HOME || '', '.local', 'bin')];
+  const pathSep = isWindows ? ';' : ':';
+  const resolvedPath = [...extraPaths, ...(process.env.PATH || '').split(pathSep)].filter(Boolean).join(pathSep);
+
+  try {
+    log.info('Creating CopilotClient...');
+    client = new CopilotClient({
+      cliPath,
+      logLevel: 'error',
+      env: { ...process.env, PATH: resolvedPath },
     });
 
+    await createNewSession();
+
+    log.info('Host ready — session initialized');
     sendMessage({ type: 'HOST_STATUS', payload: { connected: true } });
   } catch (error) {
+    log.error('Initialization failed:', error.message, error.stack || '');
     sendMessage({ type: 'HOST_STATUS', payload: { connected: false, error: error.message } });
   }
 }
@@ -210,6 +335,41 @@ async function handleMessage(message) {
       break;
     }
 
+    case 'GET_MODELS': {
+      if (!client) {
+        sendMessage({ type: 'MODELS_LIST', payload: { models: [], current: currentModel } });
+        break;
+      }
+      try {
+        const models = await client.listModels();
+        sendMessage({
+          type: 'MODELS_LIST',
+          payload: {
+            models: models.map(m => ({ id: m.id, name: m.name })),
+            current: currentModel,
+          },
+        });
+      } catch (e) {
+        log.error('listModels failed:', e.message);
+        sendMessage({ type: 'MODELS_LIST', payload: { models: [], current: currentModel } });
+      }
+      break;
+    }
+
+    case 'SET_MODEL': {
+      const { model } = message.payload;
+      log.info('Changing model to:', model);
+      currentModel = model;
+      try {
+        await createNewSession();
+        sendMessage({ type: 'HOST_STATUS', payload: { connected: true } });
+      } catch (e) {
+        log.error('Failed to re-create session with model:', model, e.message);
+        sendMessage({ type: 'HOST_STATUS', payload: { connected: false, error: e.message } });
+      }
+      break;
+    }
+
     default:
       sendMessage({ type: 'HOST_STATUS', payload: { connected: true, warning: `Unknown message type: ${message.type}` } });
   }
@@ -219,10 +379,11 @@ async function handleMessage(message) {
 
 // Prevent crashes from destroying the host when Chrome disconnects
 process.on('uncaughtException', (error) => {
-  // Silently handle stream destroyed errors during shutdown
   if (error.code === 'ERR_STREAM_DESTROYED') {
+    log.info('Stream destroyed (Chrome disconnected), exiting.');
     process.exit(0);
   }
+  log.error('Uncaught exception:', error.message, error.stack || '');
   try {
     sendMessage({ type: 'HOST_STATUS', payload: { connected: false, error: error.message } });
   } catch {}
@@ -231,27 +392,32 @@ process.on('uncaughtException', (error) => {
 
 // When Chrome closes the native messaging port, stdin ends
 process.stdin.on('end', async () => {
+  log.info('stdin closed — Chrome disconnected, shutting down.');
   if (session) await session.destroy().catch(() => {});
   if (client) await client.stop().catch(() => {});
   process.exit(0);
 });
 
+log.info('Host process started, pid:', process.pid);
 sendMessage({ type: 'HOST_STATUS', payload: { connected: false, status: 'initializing' } });
 await initialize();
 
 readMessages((message) => {
   handleMessage(message).catch((error) => {
+    log.error('handleMessage error:', error.message);
     sendMessage({ type: 'HOST_STATUS', payload: { connected: false, error: error.message } });
   });
 });
 
 process.on('SIGTERM', async () => {
+  log.info('SIGTERM received, shutting down.');
   if (session) await session.destroy().catch(() => {});
   if (client) await client.stop().catch(() => {});
   process.exit(0);
 });
 
 process.on('SIGINT', async () => {
+  log.info('SIGINT received, shutting down.');
   if (session) await session.destroy().catch(() => {});
   if (client) await client.stop().catch(() => {});
   process.exit(0);

--- a/src/panel/App.tsx
+++ b/src/panel/App.tsx
@@ -15,6 +15,8 @@ export default function App() {
   const [isLoading, setIsLoading] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [sessionId, setSessionId] = useState<string>('');
+  const [models, setModels] = useState<Array<{ id: string; name: string }>>([]);
+  const [currentModel, setCurrentModel] = useState<string | undefined>();
   const initialized = useRef(false);
 
   // Initialize on mount
@@ -55,6 +57,10 @@ export default function App() {
         case 'CONNECTION_STATUS_CHANGED':
           setConnectionStatus(message.payload.status);
           setConnectionError(message.payload.error || null);
+          // Fetch models automatically when connected
+          if (message.payload.status === 'connected') {
+            copilotClient.getModels();
+          }
           break;
 
         case 'CHAT_RESPONSE_CHUNK': {
@@ -132,8 +138,7 @@ export default function App() {
           break;
         }
 
-        case 'TOOL_CALL_RESULT': {
-          // Update the tool call message with result
+        case 'TOOL_CALL_RESULT': {          // Update the tool call message with result
           const { toolCallId, result } = message.payload;
           setMessages((prev) =>
             prev.map((m) => {
@@ -152,6 +157,11 @@ export default function App() {
           );
           break;
         }
+
+        case 'MODELS_LIST':
+          setModels(message.payload.models);
+          if (message.payload.current) setCurrentModel(message.payload.current);
+          break;
       }
     });
 
@@ -216,6 +226,11 @@ export default function App() {
     }
   }, []);
 
+  const handleModelChange = useCallback((model: string) => {
+    setCurrentModel(model);
+    copilotClient.setModel(model);
+  }, []);
+
   const handleSelectSession = useCallback(async (session: Session) => {
     setSessionId(session.id);
     setMessages(session.messages);
@@ -236,6 +251,9 @@ export default function App() {
         onConnect={handleConnect}
         onNewSession={handleNewSession}
         onShowHistory={() => setShowHistory(true)}
+        models={models}
+        currentModel={currentModel}
+        onModelChange={handleModelChange}
       />
       <MessageList messages={messages} isLoading={isLoading} />
       <ChatInput onSend={handleSend} disabled={isLoading} />

--- a/src/panel/App.tsx
+++ b/src/panel/App.tsx
@@ -207,6 +207,11 @@ export default function App() {
     [connectionStatus, sessionId],
   );
 
+  const handleStop = useCallback(() => {
+    copilotClient.cancelRequest(sessionId);
+    setIsLoading(false);
+  }, [sessionId]);
+
   const handleConnect = useCallback(() => {
     if (connectionStatus === 'disconnected' || connectionStatus === 'error') {
       copilotClient.connectToHost();
@@ -256,7 +261,7 @@ export default function App() {
         onModelChange={handleModelChange}
       />
       <MessageList messages={messages} isLoading={isLoading} />
-      <ChatInput onSend={handleSend} disabled={isLoading} />
+      <ChatInput onSend={handleSend} onStop={handleStop} isLoading={isLoading} disabled={false} />
       <SessionHistory
         isOpen={showHistory}
         onClose={() => setShowHistory(false)}

--- a/src/panel/App.tsx
+++ b/src/panel/App.tsx
@@ -68,13 +68,11 @@ export default function App() {
           const chunk = message.payload.chunk;
           setMessages((prev) => {
             const last = prev[prev.length - 1];
-            if (last && last.role === 'assistant' && (last as ChatMessage & { isStreaming?: boolean }).isStreaming) {
-              // Append to existing streaming message
+            if (last && last.role === 'assistant' && last.isStreaming) {
               return prev.map((m, i) =>
                 i === prev.length - 1 ? { ...m, content: m.content + chunk } : m
               );
             }
-            // Create new streaming message
             return [
               ...prev,
               {
@@ -83,18 +81,17 @@ export default function App() {
                 content: chunk,
                 timestamp: Date.now(),
                 isStreaming: true,
-              } as ChatMessage,
+              },
             ];
           });
           break;
         }
 
         case 'CHAT_RESPONSE_COMPLETE': {
-          // Finalize: mark streaming done (content already accumulated from chunks)
+          // Finalize streaming message with confirmed content
           setMessages((prev) => {
             const last = prev[prev.length - 1];
-            if (last && last.role === 'assistant' && (last as ChatMessage & { isStreaming?: boolean }).isStreaming) {
-              // Replace the streaming message with the final content
+            if (last && last.role === 'assistant' && last.isStreaming) {
               const finalContent = message.payload.message.content || last.content;
               return prev.map((m, i) =>
                 i === prev.length - 1
@@ -102,10 +99,13 @@ export default function App() {
                   : m
               );
             }
-            // No streaming message found, add directly
             return [...prev, message.payload.message];
           });
           setIsLoading(false);
+          // Persist assistant message to session storage (also done in service-worker, belt+suspenders)
+          if (sessionId) {
+            sessionStorage.addMessage(sessionId, message.payload.message).catch(() => {});
+          }
           break;
         }
 
@@ -209,6 +209,16 @@ export default function App() {
 
   const handleStop = useCallback(() => {
     copilotClient.cancelRequest(sessionId);
+    // Mark any in-progress streaming message as finalized
+    setMessages((prev) => {
+      const last = prev[prev.length - 1];
+      if (last && last.role === 'assistant' && last.isStreaming) {
+        return prev.map((m, i) =>
+          i === prev.length - 1 ? { ...m, isStreaming: undefined } : m
+        );
+      }
+      return prev;
+    });
     setIsLoading(false);
   }, [sessionId]);
 
@@ -261,7 +271,7 @@ export default function App() {
         onModelChange={handleModelChange}
       />
       <MessageList messages={messages} isLoading={isLoading} />
-      <ChatInput onSend={handleSend} onStop={handleStop} isLoading={isLoading} disabled={false} />
+      <ChatInput onSend={handleSend} onStop={handleStop} isLoading={isLoading} disabled={isLoading} />
       <SessionHistory
         isOpen={showHistory}
         onClose={() => setShowHistory(false)}

--- a/src/panel/components/ChatInput.tsx
+++ b/src/panel/components/ChatInput.tsx
@@ -41,9 +41,9 @@ export default function ChatInput({ onSend, onStop, disabled, isLoading }: ChatI
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Ask Copilot..."
-          disabled={disabled}
+          disabled={isLoading}
           rows={1}
-          className="flex-1 resize-none bg-transparent outline-none text-sm placeholder:opacity-50"
+          className="flex-1 resize-none bg-transparent outline-none text-sm placeholder:opacity-50 disabled:opacity-60"
           style={{ color: 'var(--copilot-text)', maxHeight: '150px' }}
         />
         <button

--- a/src/panel/components/ChatInput.tsx
+++ b/src/panel/components/ChatInput.tsx
@@ -2,10 +2,12 @@ import React, { useState, useRef, useEffect } from 'react';
 
 interface ChatInputProps {
   onSend: (message: string) => void;
+  onStop?: () => void;
   disabled?: boolean;
+  isLoading?: boolean;
 }
 
-export default function ChatInput({ onSend, disabled }: ChatInputProps) {
+export default function ChatInput({ onSend, onStop, disabled, isLoading }: ChatInputProps) {
   const [input, setInput] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -45,15 +47,21 @@ export default function ChatInput({ onSend, disabled }: ChatInputProps) {
           style={{ color: 'var(--copilot-text)', maxHeight: '150px' }}
         />
         <button
-          onClick={handleSubmit}
-          disabled={!input.trim() || disabled}
+          onClick={isLoading ? onStop : handleSubmit}
+          disabled={isLoading ? !onStop : (!input.trim() || disabled)}
           className="flex-shrink-0 rounded-md p-1.5 transition-colors disabled:opacity-30"
-          style={{ backgroundColor: input.trim() ? '#1f6feb' : 'transparent' }}
-          title="Send message"
+          style={{ backgroundColor: isLoading ? '#f85149' : (input.trim() ? '#1f6feb' : 'transparent') }}
+          title={isLoading ? 'Stop' : 'Send message'}
         >
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M1.724 1.053a.5.5 0 0 1 .552-.052l12 6.5a.5.5 0 0 1 0 .998l-12 6.5a.5.5 0 0 1-.722-.445V9.25l6.25-1.25-6.25-1.25V1.5a.5.5 0 0 1 .17-.447Z" />
-          </svg>
+          {isLoading ? (
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+              <rect x="3" y="3" width="10" height="10" rx="1" />
+            </svg>
+          ) : (
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M1.724 1.053a.5.5 0 0 1 .552-.052l12 6.5a.5.5 0 0 1 0 .998l-12 6.5a.5.5 0 0 1-.722-.445V9.25l6.25-1.25-6.25-1.25V1.5a.5.5 0 0 1 .17-.447Z" />
+            </svg>
+          )}
         </button>
       </div>
       <p className="text-center mt-2 text-xs" style={{ color: 'var(--copilot-text-secondary)' }}>

--- a/src/panel/components/HeaderBar.tsx
+++ b/src/panel/components/HeaderBar.tsx
@@ -7,6 +7,9 @@ interface HeaderBarProps {
   onConnect: () => void;
   onNewSession: () => void;
   onShowHistory: () => void;
+  models?: Array<{ id: string; name: string }>;
+  currentModel?: string;
+  onModelChange?: (model: string) => void;
 }
 
 const statusColors: Record<ConnectionStatus, string> = {
@@ -23,7 +26,7 @@ const statusLabels: Record<ConnectionStatus, string> = {
   error: 'Error',
 };
 
-export default function HeaderBar({ connectionStatus, connectionError, onConnect, onNewSession, onShowHistory }: HeaderBarProps) {
+export default function HeaderBar({ connectionStatus, connectionError, onConnect, onNewSession, onShowHistory, models = [], currentModel, onModelChange }: HeaderBarProps) {
   const tooltip = connectionError
     ? `${statusLabels[connectionStatus]}: ${connectionError}`
     : statusLabels[connectionStatus];
@@ -36,6 +39,25 @@ export default function HeaderBar({ connectionStatus, connectionError, onConnect
         <span className="font-semibold text-sm">Copilot Browser</span>
       </div>
       <div className="flex items-center gap-3">
+        {models.length > 0 && onModelChange && (
+          <select
+            value={currentModel || ''}
+            onChange={(e) => onModelChange(e.target.value)}
+            className="text-xs px-1.5 py-1 rounded border"
+            style={{
+              color: 'var(--copilot-text-secondary)',
+              backgroundColor: 'var(--copilot-bg)',
+              borderColor: 'var(--copilot-border)',
+              maxWidth: '120px',
+            }}
+            title="Select model"
+          >
+            {!currentModel && <option value="">Default model</option>}
+            {models.map(m => (
+              <option key={m.id} value={m.id}>{m.name}</option>
+            ))}
+          </select>
+        )}
         <button
           onClick={onConnect}
           className="flex items-center gap-1.5 text-xs px-2 py-1 rounded hover:opacity-80"

--- a/src/panel/components/MessageList.tsx
+++ b/src/panel/components/MessageList.tsx
@@ -35,7 +35,7 @@ export default function MessageList({ messages, isLoading }: MessageListProps) {
       {messages.map((msg) => {
         const hasContent = msg.content.trim().length > 0;
         const hasToolCalls = msg.toolCalls && msg.toolCalls.length > 0;
-        const isStreaming = (msg as ChatMessage & { isStreaming?: boolean }).isStreaming;
+        const isStreaming = msg.isStreaming;
 
         // Tool-only messages: render just the tool cards without a bubble
         if (!hasContent && hasToolCalls) {

--- a/src/panel/lib/copilot-client.ts
+++ b/src/panel/lib/copilot-client.ts
@@ -1,5 +1,5 @@
 import type { PanelMessage, BackgroundMessage } from '../../shared/messages';
-import type { ChatMessage, ConnectionStatus, ToolCall, ToolResult, TabInfo } from '../../shared/types';
+import type { ChatMessage, ConnectionStatus, ToolCall, TabInfo, ModelInfo } from '../../shared/types';
 
 type MessageHandler = (message: BackgroundMessage) => void;
 

--- a/src/panel/lib/copilot-client.ts
+++ b/src/panel/lib/copilot-client.ts
@@ -63,6 +63,16 @@ class CopilotClient {
     this.send({ type: 'GET_OPEN_TABS' });
   }
 
+  // Get available models
+  getModels(): void {
+    this.send({ type: 'GET_MODELS' });
+  }
+
+  // Set active model (re-creates host session)
+  setModel(model: string): void {
+    this.send({ type: 'SET_MODEL', payload: { model } });
+  }
+
   // Execute a tool directly
   executeTool(toolCall: ToolCall): void {
     this.send({ type: 'EXECUTE_TOOL', payload: { toolCall } });

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,6 +1,6 @@
 import type { ChatMessage, ToolCall, ToolResult, ConnectionStatus, TabInfo, ModelInfo } from './types';
 
-// Direction: Panel -> Background
+// ── Panel → Background ───────────────────────────────────────────────
 export type PanelMessage =
   | { type: 'SEND_CHAT_MESSAGE'; payload: { content: string; sessionId: string } }
   | { type: 'CANCEL_REQUEST'; payload: { sessionId: string } }
@@ -12,7 +12,7 @@ export type PanelMessage =
   | { type: 'SET_MODEL'; payload: { model: string } }
   | { type: 'EXECUTE_TOOL'; payload: { toolCall: ToolCall } };
 
-// Direction: Background -> Panel
+// ── Background → Panel ───────────────────────────────────────────────
 export type BackgroundMessage =
   | { type: 'CHAT_RESPONSE_CHUNK'; payload: { chunk: string; sessionId: string } }
   | { type: 'CHAT_RESPONSE_COMPLETE'; payload: { message: ChatMessage; sessionId: string } }
@@ -23,7 +23,7 @@ export type BackgroundMessage =
   | { type: 'OPEN_TABS'; payload: { tabs: TabInfo[] } }
   | { type: 'MODELS_LIST'; payload: { models: ModelInfo[]; current?: string } };
 
-// Direction: Background -> Content Script
+// ── Background → Content Script ──────────────────────────────────────
 export type ContentScriptMessage =
   | { type: 'GET_PAGE_CONTENT' }
   | { type: 'GET_PAGE_HTML'; payload?: { selector?: string } }
@@ -44,14 +44,14 @@ export type ContentScriptMessage =
   | { type: 'EXECUTE_JAVASCRIPT'; payload: { code: string } }
   | { type: 'WAIT_FOR_ELEMENT'; payload: { selector: string; timeout?: number } };
 
-// Content Script -> Background response
+// ── Content Script → Background ──────────────────────────────────────
 export interface ContentScriptResponse {
   success: boolean;
   data?: unknown;
   error?: string;
 }
 
-// ── Native messaging protocol (Background <-> Host process) ──────────
+// ── Native messaging protocol (Background ↔ Host process) ────────────
 // Messages sent FROM background service-worker TO host.mjs
 export type HostOutboundMessage =
   | { type: 'SEND_CHAT_MESSAGE'; payload: { content: string } }
@@ -70,63 +70,3 @@ export type HostInboundMessage =
   | { type: 'TOOL_EXECUTION_START'; payload: { toolCallId: string; toolName: string } }
   | { type: 'TOOL_EXECUTION_COMPLETE'; payload: { toolCallId: string; toolName: string } }
   | { type: 'MODELS_LIST'; payload: { models: ModelInfo[]; current?: string } };
-
-
-// Direction: Panel -> Background
-export type PanelMessage =
-  | { type: 'SEND_CHAT_MESSAGE'; payload: { content: string; sessionId: string } }
-  | { type: 'CANCEL_REQUEST'; payload: { sessionId: string } }
-  | { type: 'GET_CONNECTION_STATUS' }
-  | { type: 'CONNECT_TO_HOST' }
-  | { type: 'DISCONNECT_FROM_HOST' }
-  | { type: 'GET_OPEN_TABS' }
-  | { type: 'GET_MODELS' }
-  | { type: 'SET_MODEL'; payload: { model: string } }
-  | { type: 'EXECUTE_TOOL'; payload: { toolCall: ToolCall } };
-
-// Direction: Background -> Panel
-export type BackgroundMessage =
-  | { type: 'CHAT_RESPONSE_CHUNK'; payload: { chunk: string; sessionId: string } }
-  | { type: 'CHAT_RESPONSE_COMPLETE'; payload: { message: ChatMessage; sessionId: string } }
-  | { type: 'CHAT_RESPONSE_ERROR'; payload: { error: string; sessionId: string } }
-  | { type: 'TOOL_CALL_START'; payload: { toolCall: ToolCall; sessionId: string } }
-  | { type: 'TOOL_CALL_RESULT'; payload: { toolCallId: string; result: ToolResult; sessionId: string } }
-  | { type: 'CONNECTION_STATUS_CHANGED'; payload: { status: ConnectionStatus; error?: string | null } }
-  | { type: 'OPEN_TABS'; payload: { tabs: TabInfo[] } }
-  | { type: 'MODELS_LIST'; payload: { models: Array<{ id: string; name: string }>; current?: string } };
-
-// Direction: Background -> Content Script
-export type ContentScriptMessage =
-  | { type: 'GET_PAGE_CONTENT' }
-  | { type: 'GET_PAGE_HTML'; payload?: { selector?: string } }
-  | { type: 'GET_PAGE_STRUCTURE' }
-  | { type: 'QUERY_SELECTOR'; payload: { selector: string } }
-  | { type: 'QUERY_SELECTOR_ALL'; payload: { selector: string } }
-  | { type: 'GET_PAGE_TABLES' }
-  | { type: 'GET_PAGE_LINKS' }
-  | { type: 'GET_PAGE_FORMS' }
-  | { type: 'CLICK_ELEMENT'; payload: { selector: string } }
-  | { type: 'TYPE_TEXT'; payload: { selector: string; text: string } }
-  | { type: 'FILL_FORM'; payload: { fields: Record<string, string> } }
-  | { type: 'SELECT_OPTION'; payload: { selector: string; value: string } }
-  | { type: 'SCROLL_PAGE'; payload: { direction?: 'up' | 'down'; amount?: number; selector?: string } }
-  | { type: 'PRESS_KEY'; payload: { key: string } }
-  | { type: 'HOVER_ELEMENT'; payload: { selector: string } }
-  | { type: 'HIGHLIGHT_ELEMENT'; payload: { selector: string; color?: string } }
-  | { type: 'EXECUTE_JAVASCRIPT'; payload: { code: string } }
-  | { type: 'WAIT_FOR_ELEMENT'; payload: { selector: string; timeout?: number } }
-  | { type: 'HOVER_ELEMENT'; payload: { selector: string } };
-
-// Content Script -> Background response
-export interface ContentScriptResponse {
-  success: boolean;
-  data?: unknown;
-  error?: string;
-}
-
-// Native messaging (Background <-> Host)
-export type NativeMessage =
-  | { type: 'COPILOT_REQUEST'; payload: { method: string; params: unknown } }
-  | { type: 'COPILOT_RESPONSE'; payload: { id: string; result?: unknown; error?: unknown } }
-  | { type: 'COPILOT_STREAM'; payload: { id: string; chunk: string } }
-  | { type: 'HOST_STATUS'; payload: { connected: boolean; error?: string } };

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -8,6 +8,8 @@ export type PanelMessage =
   | { type: 'CONNECT_TO_HOST' }
   | { type: 'DISCONNECT_FROM_HOST' }
   | { type: 'GET_OPEN_TABS' }
+  | { type: 'GET_MODELS' }
+  | { type: 'SET_MODEL'; payload: { model: string } }
   | { type: 'EXECUTE_TOOL'; payload: { toolCall: ToolCall } };
 
 // Direction: Background -> Panel
@@ -18,7 +20,8 @@ export type BackgroundMessage =
   | { type: 'TOOL_CALL_START'; payload: { toolCall: ToolCall; sessionId: string } }
   | { type: 'TOOL_CALL_RESULT'; payload: { toolCallId: string; result: ToolResult; sessionId: string } }
   | { type: 'CONNECTION_STATUS_CHANGED'; payload: { status: ConnectionStatus; error?: string | null } }
-  | { type: 'OPEN_TABS'; payload: { tabs: TabInfo[] } };
+  | { type: 'OPEN_TABS'; payload: { tabs: TabInfo[] } }
+  | { type: 'MODELS_LIST'; payload: { models: Array<{ id: string; name: string }>; current?: string } };
 
 // Direction: Background -> Content Script
 export type ContentScriptMessage =

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,4 +1,76 @@
-import type { ChatMessage, ToolCall, ToolResult, ConnectionStatus, TabInfo } from './types';
+import type { ChatMessage, ToolCall, ToolResult, ConnectionStatus, TabInfo, ModelInfo } from './types';
+
+// Direction: Panel -> Background
+export type PanelMessage =
+  | { type: 'SEND_CHAT_MESSAGE'; payload: { content: string; sessionId: string } }
+  | { type: 'CANCEL_REQUEST'; payload: { sessionId: string } }
+  | { type: 'GET_CONNECTION_STATUS' }
+  | { type: 'CONNECT_TO_HOST' }
+  | { type: 'DISCONNECT_FROM_HOST' }
+  | { type: 'GET_OPEN_TABS' }
+  | { type: 'GET_MODELS' }
+  | { type: 'SET_MODEL'; payload: { model: string } }
+  | { type: 'EXECUTE_TOOL'; payload: { toolCall: ToolCall } };
+
+// Direction: Background -> Panel
+export type BackgroundMessage =
+  | { type: 'CHAT_RESPONSE_CHUNK'; payload: { chunk: string; sessionId: string } }
+  | { type: 'CHAT_RESPONSE_COMPLETE'; payload: { message: ChatMessage; sessionId: string } }
+  | { type: 'CHAT_RESPONSE_ERROR'; payload: { error: string; sessionId: string } }
+  | { type: 'TOOL_CALL_START'; payload: { toolCall: ToolCall; sessionId: string } }
+  | { type: 'TOOL_CALL_RESULT'; payload: { toolCallId: string; result: ToolResult; sessionId: string } }
+  | { type: 'CONNECTION_STATUS_CHANGED'; payload: { status: ConnectionStatus; error?: string | null } }
+  | { type: 'OPEN_TABS'; payload: { tabs: TabInfo[] } }
+  | { type: 'MODELS_LIST'; payload: { models: ModelInfo[]; current?: string } };
+
+// Direction: Background -> Content Script
+export type ContentScriptMessage =
+  | { type: 'GET_PAGE_CONTENT' }
+  | { type: 'GET_PAGE_HTML'; payload?: { selector?: string } }
+  | { type: 'GET_PAGE_STRUCTURE' }
+  | { type: 'QUERY_SELECTOR'; payload: { selector: string } }
+  | { type: 'QUERY_SELECTOR_ALL'; payload: { selector: string } }
+  | { type: 'GET_PAGE_TABLES' }
+  | { type: 'GET_PAGE_LINKS' }
+  | { type: 'GET_PAGE_FORMS' }
+  | { type: 'CLICK_ELEMENT'; payload: { selector: string } }
+  | { type: 'TYPE_TEXT'; payload: { selector: string; text: string } }
+  | { type: 'FILL_FORM'; payload: { fields: Record<string, string> } }
+  | { type: 'SELECT_OPTION'; payload: { selector: string; value: string } }
+  | { type: 'SCROLL_PAGE'; payload: { direction?: 'up' | 'down'; amount?: number; selector?: string } }
+  | { type: 'PRESS_KEY'; payload: { key: string } }
+  | { type: 'HOVER_ELEMENT'; payload: { selector: string } }
+  | { type: 'HIGHLIGHT_ELEMENT'; payload: { selector: string; color?: string } }
+  | { type: 'EXECUTE_JAVASCRIPT'; payload: { code: string } }
+  | { type: 'WAIT_FOR_ELEMENT'; payload: { selector: string; timeout?: number } };
+
+// Content Script -> Background response
+export interface ContentScriptResponse {
+  success: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+// ── Native messaging protocol (Background <-> Host process) ──────────
+// Messages sent FROM background service-worker TO host.mjs
+export type HostOutboundMessage =
+  | { type: 'SEND_CHAT_MESSAGE'; payload: { content: string } }
+  | { type: 'CANCEL_REQUEST' }
+  | { type: 'TOOL_CALL_RESULT'; payload: { toolCallId: string; result: ToolResult } }
+  | { type: 'GET_MODELS' }
+  | { type: 'SET_MODEL'; payload: { model: string } };
+
+// Messages sent FROM host.mjs TO background service-worker
+export type HostInboundMessage =
+  | { type: 'HOST_STATUS'; payload: { connected: boolean; status?: string; error?: string; warning?: string } }
+  | { type: 'CHAT_RESPONSE'; payload: { content: string; done: boolean } }
+  | { type: 'CHAT_RESPONSE_CHUNK'; payload: { content: string } }
+  | { type: 'CHAT_RESPONSE_ERROR'; payload: { error: string } }
+  | { type: 'TOOL_CALL_REQUEST'; payload: { toolCallId: string; toolName: string; arguments: Record<string, unknown> } }
+  | { type: 'TOOL_EXECUTION_START'; payload: { toolCallId: string; toolName: string } }
+  | { type: 'TOOL_EXECUTION_COMPLETE'; payload: { toolCallId: string; toolName: string } }
+  | { type: 'MODELS_LIST'; payload: { models: ModelInfo[]; current?: string } };
+
 
 // Direction: Panel -> Background
 export type PanelMessage =

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -8,6 +8,8 @@ export interface ChatMessage {
   content: string;
   timestamp: number;
   toolCalls?: ToolCall[];
+  /** True while assistant response is still streaming in */
+  isStreaming?: boolean;
 }
 
 // Tool call and result
@@ -51,6 +53,12 @@ export interface Session {
 
 // Connection status
 export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
+
+// Model info
+export interface ModelInfo {
+  id: string;
+  name: string;
+}
 
 // Tab info
 export interface TabInfo {


### PR DESCRIPTION
## Summary

Work done in this branch:

### 🐛 Bug fixes
- **Tool execution fix**: Add `onPermissionRequest: approveAll` to `createSession()` — without it the SDK silently denies every tool call in <200ms
- **Session routing fix**: Route chat responses only to the panel that sent the message (`activePort` tracking), not broadcast to all panels
- **Tab detection fix**: Use `lastFocusedWindow` + URL filtering to avoid detecting the extension's own side panel window

### ✨ New features
- **Model selector**: Dropdown in HeaderBar to list and switch Copilot models (`client.listModels()` + session recreation)
- **Stop button**: Red ■ button replaces ▶ send button during loading; calls `session.abort()` to stop generation mid-stream

### 🛠 Infrastructure
- `findCopilotCli()`: Auto-locate the Copilot CLI binary across common paths
- Setup scripts: `setup-host.sh`, `register-host.sh`, `test-host.sh`
- Tool name prefix (`github_copilot_browser__`) to avoid conflicts with CLI built-in tools
- `wrapper.bat` logging via `2>>` (stderr only, avoids corrupting Chrome native messaging protocol)

### 📝 Docs
- Full README rewrite: WSL architecture diagram, troubleshooting table, `2>>` warning, custom tools explanation
