### PR TITLE
fix: use lastFocusedWindow for active tab detection in side panel

### DIFF
--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -13,8 +13,23 @@ export async function getOpenTabs(): Promise<TabInfo[]> {
 }
 
 export async function getActiveTab(): Promise<chrome.tabs.Tab | null> {
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  return tab || null;
+  // Use lastFocusedWindow — currentWindow:true returns the extension's own side panel
+  // window when the panel has focus, not the browser tab the user is viewing.
+  const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+  if (tab) {
+    // Skip chrome-extension://, chrome://, edge:// — content scripts can't run there
+    if (tab.url && !tab.url.startsWith('chrome-extension://') && !tab.url.startsWith('chrome://') && !tab.url.startsWith('edge://')) {
+      return tab;
+    }
+  }
+  // Fallback: search all windows for an active non-restricted tab
+  const allActive = await chrome.tabs.query({ active: true });
+  return allActive.find(t =>
+    t.url &&
+    !t.url.startsWith('chrome-extension://') &&
+    !t.url.startsWith('chrome://') &&
+    !t.url.startsWith('edge://')
+  ) || null;
 }
 
 export async function navigateTo(url: string, tabId?: number): Promise<void> {


### PR DESCRIPTION
## Problem

All content-script tools (`get_page_content`, `click_element`, `capture_screenshot`, etc.) fail with **"No active tab"** whenever the side panel has keyboard focus.

## Root cause

`chrome.tabs.query({ active: true, currentWindow: true })` returns the extension's own side-panel window when the panel has focus — **not** the browser tab the user is looking at.

## Fix

Use `lastFocusedWindow: true` instead of `currentWindow: true`, then filter out `chrome-extension://`, `chrome://`, and `edge://` URLs (content scripts cannot be injected into those). Add a fallback that searches all windows when the primary query returns a restricted URL.

```ts
// Before
const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });

// After
const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
// + filter chrome-extension://, chrome://, edge:// URLs
```

This is critical for the extension to work correctly when used as a side panel (which is the primary use case).

## Files changed
- `src/background/tab-manager.ts`

---
> Part of the changes described in [patniko/github-copilot-browser#1](https://github.com/patniko/github-copilot-browser/issues/1)