### PR TITLE
feat: model selector — list and switch Copilot models from the header

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -76,6 +76,14 @@ async function handlePanelMessage(message: PanelMessage, port: chrome.runtime.Po
       break;
     }
 
+    case 'GET_MODELS':
+      nativeMessaging.send({ type: 'GET_MODELS' });
+      break;
+
+    case 'SET_MODEL':
+      nativeMessaging.send({ type: 'SET_MODEL', payload: message.payload });
+      break;
+
     case 'EXECUTE_TOOL':
       break;
   }
@@ -151,6 +159,14 @@ nativeMessaging.onMessage((message: any) => {
     case 'TOOL_EXECUTION_START':
     case 'TOOL_EXECUTION_COMPLETE':
       // Already handled via TOOL_CALL_REQUEST flow
+      break;
+
+    case 'MODELS_LIST':
+      // Broadcast model list to all panels
+      sendToPanels({
+        type: 'MODELS_LIST',
+        payload: message.payload,
+      });
       break;
   }
 });

--- a/src/host/host.mjs
+++ b/src/host/host.mjs
@@ -210,6 +210,19 @@ async function handleMessage(message) {
       break;
     }
 
+    case 'GET_MODELS': {
+      const models = client ? await client.getModels().catch(() => []) : [];
+      sendMessage({ type: 'MODELS_LIST', payload: { models } });
+      break;
+    }
+
+    case 'SET_MODEL': {
+      if (client) {
+        await client.setModel(message.payload.model).catch(() => {});
+      }
+      break;
+    }
+
     default:
       sendMessage({ type: 'HOST_STATUS', payload: { connected: true, warning: `Unknown message type: ${message.type}` } });
   }

--- a/src/panel/App.tsx
+++ b/src/panel/App.tsx
@@ -5,7 +5,7 @@ import ChatInput from './components/ChatInput';
 import SessionHistory from './components/SessionHistory';
 import { copilotClient } from './lib/copilot-client';
 import * as sessionStorage from './lib/session-storage';
-import type { ChatMessage, ConnectionStatus, Session } from '../shared/types';
+import type { ChatMessage, ConnectionStatus, Session, ModelInfo } from '../shared/types';
 import type { BackgroundMessage } from '../shared/messages';
 
 export default function App() {
@@ -15,6 +15,8 @@ export default function App() {
   const [isLoading, setIsLoading] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [sessionId, setSessionId] = useState<string>('');
+  const [models, setModels] = useState<ModelInfo[]>([]);
+  const [currentModel, setCurrentModel] = useState<string>('');
   const initialized = useRef(false);
 
   // Initialize on mount
@@ -55,6 +57,15 @@ export default function App() {
         case 'CONNECTION_STATUS_CHANGED':
           setConnectionStatus(message.payload.status);
           setConnectionError(message.payload.error || null);
+          // Request model list when connected
+          if (message.payload.status === 'connected') {
+            copilotClient.getModels();
+          }
+          break;
+
+        case 'MODELS_LIST':
+          setModels(message.payload.models);
+          if (message.payload.current) setCurrentModel(message.payload.current);
           break;
 
         case 'CHAT_RESPONSE_CHUNK': {
@@ -205,6 +216,11 @@ export default function App() {
     }
   }, [connectionStatus]);
 
+  const handleModelChange = useCallback((model: string) => {
+    setCurrentModel(model);
+    copilotClient.setModel(model);
+  }, []);
+
   const handleNewSession = useCallback(async () => {
     setMessages([]);
     setIsLoading(false);
@@ -236,6 +252,9 @@ export default function App() {
         onConnect={handleConnect}
         onNewSession={handleNewSession}
         onShowHistory={() => setShowHistory(true)}
+        models={models}
+        currentModel={currentModel}
+        onModelChange={handleModelChange}
       />
       <MessageList messages={messages} isLoading={isLoading} />
       <ChatInput onSend={handleSend} disabled={isLoading} />

--- a/src/panel/components/HeaderBar.tsx
+++ b/src/panel/components/HeaderBar.tsx
@@ -7,6 +7,9 @@ interface HeaderBarProps {
   onConnect: () => void;
   onNewSession: () => void;
   onShowHistory: () => void;
+  models?: Array<{ id: string; name: string }>;
+  currentModel?: string;
+  onModelChange?: (model: string) => void;
 }
 
 const statusColors: Record<ConnectionStatus, string> = {
@@ -23,7 +26,7 @@ const statusLabels: Record<ConnectionStatus, string> = {
   error: 'Error',
 };
 
-export default function HeaderBar({ connectionStatus, connectionError, onConnect, onNewSession, onShowHistory }: HeaderBarProps) {
+export default function HeaderBar({ connectionStatus, connectionError, onConnect, onNewSession, onShowHistory, models = [], currentModel, onModelChange }: HeaderBarProps) {
   const tooltip = connectionError
     ? `${statusLabels[connectionStatus]}: ${connectionError}`
     : statusLabels[connectionStatus];
@@ -36,6 +39,25 @@ export default function HeaderBar({ connectionStatus, connectionError, onConnect
         <span className="font-semibold text-sm">Copilot Browser</span>
       </div>
       <div className="flex items-center gap-3">
+        {models.length > 0 && onModelChange && (
+          <select
+            value={currentModel || ''}
+            onChange={(e) => onModelChange(e.target.value)}
+            className="text-xs px-1.5 py-1 rounded border"
+            style={{
+              color: 'var(--copilot-text-secondary)',
+              backgroundColor: 'var(--copilot-bg)',
+              borderColor: 'var(--copilot-border)',
+              maxWidth: '120px',
+            }}
+            title="Select model"
+          >
+            {!currentModel && <option value="">Default model</option>}
+            {models.map(m => (
+              <option key={m.id} value={m.id}>{m.name}</option>
+            ))}
+          </select>
+        )}
         <button
           onClick={onConnect}
           className="flex items-center gap-1.5 text-xs px-2 py-1 rounded hover:opacity-80"

--- a/src/panel/lib/copilot-client.ts
+++ b/src/panel/lib/copilot-client.ts
@@ -58,6 +58,16 @@ class CopilotClient {
     this.send({ type: 'DISCONNECT_FROM_HOST' });
   }
 
+  // Get available models
+  getModels(): void {
+    this.send({ type: 'GET_MODELS' });
+  }
+
+  // Set active model
+  setModel(model: string): void {
+    this.send({ type: 'SET_MODEL', payload: { model } });
+  }
+
   // Get open tabs
   getOpenTabs(): void {
     this.send({ type: 'GET_OPEN_TABS' });

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, ToolCall, ToolResult, ConnectionStatus, TabInfo } from './types';
+import type { ChatMessage, ToolCall, ToolResult, ConnectionStatus, TabInfo, ModelInfo } from './types';
 
 // Direction: Panel -> Background
 export type PanelMessage =
@@ -8,6 +8,8 @@ export type PanelMessage =
   | { type: 'CONNECT_TO_HOST' }
   | { type: 'DISCONNECT_FROM_HOST' }
   | { type: 'GET_OPEN_TABS' }
+  | { type: 'GET_MODELS' }
+  | { type: 'SET_MODEL'; payload: { model: string } }
   | { type: 'EXECUTE_TOOL'; payload: { toolCall: ToolCall } };
 
 // Direction: Background -> Panel
@@ -17,6 +19,7 @@ export type BackgroundMessage =
   | { type: 'CHAT_RESPONSE_ERROR'; payload: { error: string; sessionId: string } }
   | { type: 'TOOL_CALL_START'; payload: { toolCall: ToolCall; sessionId: string } }
   | { type: 'TOOL_CALL_RESULT'; payload: { toolCallId: string; result: ToolResult; sessionId: string } }
+  | { type: 'MODELS_LIST'; payload: { models: ModelInfo[]; current?: string } }
   | { type: 'CONNECTION_STATUS_CHANGED'; payload: { status: ConnectionStatus; error?: string | null } }
   | { type: 'OPEN_TABS'; payload: { tabs: TabInfo[] } };
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -49,6 +49,12 @@ export interface Session {
   updatedAt: number;
 }
 
+// Model info
+export interface ModelInfo {
+  id: string;
+  name: string;
+}
+
 // Connection status
 export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
 


### PR DESCRIPTION
## Feature

Adds a **model selector dropdown** in the header bar, allowing users to list and switch between available Copilot models without restarting the session.

### UX behaviour

- On connect, the extension automatically requests the available model list (`GET_MODELS`)
- A `<select>` dropdown appears in the header when models are available (hidden otherwise)
- Selecting a model sends `SET_MODEL` through the message stack to the host
- The current model is tracked in state and shown as the selected option

### Message flow

```
Panel: GET_MODELS
  → service-worker → host: client.getModels()
  → host → service-worker: MODELS_LIST { models, current? }
  → service-worker broadcasts to all panels
  → Panel: renders <select> with model options

Panel: SET_MODEL { model }
  → service-worker → host: client.setModel(model)
```

### Depends on
- [PR-4](https://github.com/svg153/github-copilot-browser/pull/4) (clean `messages.ts`) — adds `GET_MODELS`/`SET_MODEL`/`MODELS_LIST` types
- [PR-7](https://github.com/svg153/github-copilot-browser/pull/7) (`types.ts`) — adds `ModelInfo` interface alongside `isStreaming`

## Files changed
- `src/shared/types.ts` — add `ModelInfo` interface
- `src/shared/messages.ts` — add `GET_MODELS`, `SET_MODEL` (Panel→BG), `MODELS_LIST` (BG→Panel + host inbound)
- `src/host/host.mjs` — handle `GET_MODELS` and `SET_MODEL`
- `src/background/service-worker.ts` — forward `GET_MODELS`/`SET_MODEL`, broadcast `MODELS_LIST`
- `src/panel/lib/copilot-client.ts` — add `getModels()` and `setModel()` helpers
- `src/panel/App.tsx` — model state, `handleModelChange`, request models on connect
- `src/panel/components/HeaderBar.tsx` — `<select>` dropdown with model options

---
> Part of the changes described in [patniko/github-copilot-browser#1](https://github.com/patniko/github-copilot-browser/issues/1)