### PR TITLE
refactor: replace wrong NativeMessage type with correct host protocol types

### DIFF
--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -39,8 +39,7 @@ export type ContentScriptMessage =
   | { type: 'HOVER_ELEMENT'; payload: { selector: string } }
   | { type: 'HIGHLIGHT_ELEMENT'; payload: { selector: string; color?: string } }
   | { type: 'EXECUTE_JAVASCRIPT'; payload: { code: string } }
-  | { type: 'WAIT_FOR_ELEMENT'; payload: { selector: string; timeout?: number } }
-  | { type: 'HOVER_ELEMENT'; payload: { selector: string } };
+  | { type: 'WAIT_FOR_ELEMENT'; payload: { selector: string; timeout?: number } };
 
 // Content Script -> Background response
 export interface ContentScriptResponse {
@@ -49,9 +48,21 @@ export interface ContentScriptResponse {
   error?: string;
 }
 
-// Native messaging (Background <-> Host)
-export type NativeMessage =
-  | { type: 'COPILOT_REQUEST'; payload: { method: string; params: unknown } }
-  | { type: 'COPILOT_RESPONSE'; payload: { id: string; result?: unknown; error?: unknown } }
-  | { type: 'COPILOT_STREAM'; payload: { id: string; chunk: string } }
-  | { type: 'HOST_STATUS'; payload: { connected: boolean; error?: string } };
+// Native messaging (Background -> Host)
+export type HostOutboundMessage =
+  | { type: 'SEND_CHAT_MESSAGE'; payload: { content: string } }
+  | { type: 'TOOL_CALL_RESULT'; payload: { toolCallId: string; result: ToolResult } }
+  | { type: 'CANCEL_REQUEST'; payload: { sessionId: string } };
+
+// Native messaging (Host -> Background)
+export type HostInboundMessage =
+  | { type: 'HOST_STATUS'; payload: { connected: boolean; error?: string; status?: string; warning?: string } }
+  | { type: 'CHAT_RESPONSE'; payload: { content: string } }
+  | { type: 'CHAT_RESPONSE_CHUNK'; payload: { content: string } }
+  | { type: 'CHAT_RESPONSE_ERROR'; payload: { error: string } }
+  | { type: 'TOOL_CALL_REQUEST'; payload: { toolCallId: string; toolName: string; arguments: Record<string, unknown> } }
+  | { type: 'TOOL_EXECUTION_START'; payload: { toolName: string } }
+  | { type: 'TOOL_EXECUTION_COMPLETE'; payload: { toolName: string; result: unknown } };
+
+/** @deprecated Use HostOutboundMessage and HostInboundMessage instead */
+export type NativeMessage = HostOutboundMessage | HostInboundMessage;


### PR DESCRIPTION
## Problem

`NativeMessage` — the type used for all communication between the service-worker and native host — was typed with **fictional variants** that don't exist in the actual protocol:

```ts
// Before — none of these types are real
export type NativeMessage =
  | { type: 'COPILOT_REQUEST'; payload: { method: string; params: unknown } }
  | { type: 'COPILOT_RESPONSE'; payload: { id: string; result?: unknown; error?: unknown } }
  | { type: 'COPILOT_STREAM'; payload: { id: string; chunk: string } }
  | { type: 'HOST_STATUS'; payload: { connected: boolean; error?: string } };
```

TypeScript provided **zero type safety** for the entire native messaging layer. Any typo in a message type would go undetected.

Also: `ContentScriptMessage` had a duplicate `HOVER_ELEMENT` entry in its union type.

## Fix

Replace `NativeMessage` with two correctly-typed unions that match the actual protocol:

- **`HostOutboundMessage`** — messages the service-worker sends *to* the host (`SEND_CHAT_MESSAGE`, `TOOL_CALL_RESULT`, `CANCEL_REQUEST`)
- **`HostInboundMessage`** — messages the host sends *to* the service-worker (`HOST_STATUS`, `CHAT_RESPONSE`, `CHAT_RESPONSE_CHUNK`, `CHAT_RESPONSE_ERROR`, `TOOL_CALL_REQUEST`, `TOOL_EXECUTION_START`, `TOOL_EXECUTION_COMPLETE`)

`NativeMessage` is kept as a `@deprecated` alias (`= HostOutboundMessage | HostInboundMessage`) for backward compatibility.

Remove the duplicate `HOVER_ELEMENT` from `ContentScriptMessage`.

## Files changed
- `src/shared/messages.ts`

---
> Part of the changes described in [patniko/github-copilot-browser#1](https://github.com/patniko/github-copilot-browser/issues/1)