### PR TITLE
fix: route chat responses only to the panel that initiated the request

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -4,15 +4,18 @@ import * as tabManager from './tab-manager';
 import type { PanelMessage, BackgroundMessage } from '../shared/messages';
 import type { ConnectionStatus } from '../shared/types';
 
-console.log('[Background] Service worker loaded');
-
 // Track panel connections
 const panelPorts: chrome.runtime.Port[] = [];
+
+// Track which panel initiated the current request (receives responses/tool calls).
+// With multiple side panels open, responses must go only to the panel that sent
+// the message — not broadcast to all panels.
+let activePort: chrome.runtime.Port | null = null;
+let activeSessionId: string = 'current';
 
 // Listen for connections from the side panel
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name === 'copilot-panel') {
-    console.log('[Background] Panel connected');
     panelPorts.push(port);
 
     port.onMessage.addListener((message: PanelMessage) => {
@@ -22,7 +25,7 @@ chrome.runtime.onConnect.addListener((port) => {
     port.onDisconnect.addListener(() => {
       const index = panelPorts.indexOf(port);
       if (index > -1) panelPorts.splice(index, 1);
-      console.log('[Background] Panel disconnected');
+      if (activePort === port) activePort = null;
     });
 
     // Send current connection status
@@ -59,6 +62,9 @@ async function handlePanelMessage(message: PanelMessage, port: chrome.runtime.Po
 
     case 'SEND_CHAT_MESSAGE': {
       const { content, sessionId } = message.payload;
+      // Bind this panel as the active recipient for the duration of this request
+      activePort = port;
+      activeSessionId = sessionId;
       try {
         nativeMessaging.send({
           type: 'SEND_CHAT_MESSAGE',
@@ -81,15 +87,14 @@ async function handlePanelMessage(message: PanelMessage, port: chrome.runtime.Po
   }
 }
 
-// Forward native messaging responses from host to panels
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 nativeMessaging.onMessage((message: any) => {
-  const sessionId = 'current';
-
   switch (message.type) {
     // Full assistant response
     case 'CHAT_RESPONSE':
-      sendToPanels({
+      // Skip empty responses (occur when the LLM calls tools without a text reply)
+      if (!message.payload.content) break;
+      sendToActivePanel({
         type: 'CHAT_RESPONSE_COMPLETE',
         payload: {
           message: {
@@ -98,24 +103,24 @@ nativeMessaging.onMessage((message: any) => {
             content: message.payload.content,
             timestamp: Date.now(),
           },
-          sessionId,
+          sessionId: activeSessionId,
         },
       });
       break;
 
     // Streaming chunk
     case 'CHAT_RESPONSE_CHUNK':
-      sendToPanels({
+      sendToActivePanel({
         type: 'CHAT_RESPONSE_CHUNK',
-        payload: { chunk: message.payload.content, sessionId },
+        payload: { chunk: message.payload.content, sessionId: activeSessionId },
       });
       break;
 
     // Chat error
     case 'CHAT_RESPONSE_ERROR':
-      sendToPanels({
+      sendToActivePanel({
         type: 'CHAT_RESPONSE_ERROR',
-        payload: { error: message.payload.error, sessionId },
+        payload: { error: message.payload.error, sessionId: activeSessionId },
       });
       break;
 
@@ -123,39 +128,42 @@ nativeMessaging.onMessage((message: any) => {
     case 'TOOL_CALL_REQUEST': {
       const { toolCallId, toolName, arguments: args } = message.payload;
 
-      sendToPanels({
+      sendToActivePanel({
         type: 'TOOL_CALL_START',
         payload: {
           toolCall: { id: toolCallId, name: toolName, parameters: args || {}, status: 'running' },
-          sessionId,
+          sessionId: activeSessionId,
         },
       });
 
-      // Execute the tool in the extension
+      // Execute the tool and send result back to host
       executeTool(toolName, args || {}).then((result) => {
-        // Send result back to the native host so the SDK can feed it to the LLM
         nativeMessaging.send({
           type: 'TOOL_CALL_RESULT',
           payload: { toolCallId, result },
         });
-
-        sendToPanels({
+        sendToActivePanel({
           type: 'TOOL_CALL_RESULT',
-          payload: { toolCallId, result, sessionId },
+          payload: { toolCallId, result, sessionId: activeSessionId },
+        });
+      }).catch((error) => {
+        console.error('[Background] Tool execution error:', toolName, error.message);
+        nativeMessaging.send({
+          type: 'TOOL_CALL_RESULT',
+          payload: { toolCallId, result: { success: false, error: error.message } },
         });
       });
       break;
     }
 
-    // Tool execution lifecycle events from the host
+    // Tool execution lifecycle events — handled via TOOL_CALL_REQUEST flow
     case 'TOOL_EXECUTION_START':
     case 'TOOL_EXECUTION_COMPLETE':
-      // Already handled via TOOL_CALL_REQUEST flow
       break;
   }
 });
 
-// Forward connection status changes to panels
+// Forward connection status changes to all panels (not session-specific)
 nativeMessaging.onStatus((status: ConnectionStatus) => {
   sendToPanels({
     type: 'CONNECTION_STATUS_CHANGED',
@@ -180,6 +188,10 @@ chrome.runtime.onMessage.addListener((message, sender) => {
 // Helper functions
 function sendToPanel(port: chrome.runtime.Port, message: BackgroundMessage): void {
   port.postMessage(message);
+}
+
+function sendToActivePanel(message: BackgroundMessage): void {
+  if (activePort) sendToPanel(activePort, message);
 }
 
 function sendToPanels(message: BackgroundMessage): void {


### PR DESCRIPTION
## Problem

With multiple browser windows open (each with the extension side panel), **responses from one conversation appear in the wrong panel**. If you have two sessions running, messages cross-contaminate between them.

Also:
- Blank message bubbles appear when the LLM calls tools with no accompanying text (empty `CHAT_RESPONSE` payloads)
- Tool execution errors are silently swallowed (no `.catch()` on `executeTool()`)

## Root cause

`sendToPanels()` broadcasts **every** response to all connected panel ports. There is no concept of which panel initiated the current request.

## Fix

- Track `activePort` — the port that sent the last `SEND_CHAT_MESSAGE`
- Track `activeSessionId` for correct session routing
- New `sendToActivePanel()` helper routes `CHAT_RESPONSE_*` and `TOOL_CALL_*` only to the initiating panel
- `CONNECTION_STATUS_CHANGED` still broadcasts to all panels (intentional — all panels should know the host status)
- Clear `activePort` when that panel disconnects
- Skip empty `CHAT_RESPONSE` content (prevents blank bubbles)
- Add `.catch()` to `executeTool()` to prevent silent failures

## Files changed
- `src/background/service-worker.ts`

---
> Part of the changes described in [patniko/github-copilot-browser#1](https://github.com/patniko/github-copilot-browser/issues/1)