### PR TITLE
fix: add isStreaming to ChatMessage type, remove unsafe casts

### DIFF
--- a/src/panel/App.tsx
+++ b/src/panel/App.tsx
@@ -62,7 +62,7 @@ export default function App() {
           const chunk = message.payload.chunk;
           setMessages((prev) => {
             const last = prev[prev.length - 1];
-            if (last && last.role === 'assistant' && (last as ChatMessage & { isStreaming?: boolean }).isStreaming) {
+            if (last && last.role === 'assistant' && last.isStreaming) {
               // Append to existing streaming message
               return prev.map((m, i) =>
                 i === prev.length - 1 ? { ...m, content: m.content + chunk } : m
@@ -77,7 +77,7 @@ export default function App() {
                 content: chunk,
                 timestamp: Date.now(),
                 isStreaming: true,
-              } as ChatMessage,
+              },
             ];
           });
           break;
@@ -87,7 +87,7 @@ export default function App() {
           // Finalize: mark streaming done (content already accumulated from chunks)
           setMessages((prev) => {
             const last = prev[prev.length - 1];
-            if (last && last.role === 'assistant' && (last as ChatMessage & { isStreaming?: boolean }).isStreaming) {
+            if (last && last.role === 'assistant' && last.isStreaming) {
               // Replace the streaming message with the final content
               const finalContent = message.payload.message.content || last.content;
               return prev.map((m, i) =>

--- a/src/panel/components/MessageList.tsx
+++ b/src/panel/components/MessageList.tsx
@@ -35,7 +35,7 @@ export default function MessageList({ messages, isLoading }: MessageListProps) {
       {messages.map((msg) => {
         const hasContent = msg.content.trim().length > 0;
         const hasToolCalls = msg.toolCalls && msg.toolCalls.length > 0;
-        const isStreaming = (msg as ChatMessage & { isStreaming?: boolean }).isStreaming;
+        const isStreaming = msg.isStreaming;
 
         // Tool-only messages: render just the tool cards without a bubble
         if (!hasContent && hasToolCalls) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -8,6 +8,8 @@ export interface ChatMessage {
   content: string;
   timestamp: number;
   toolCalls?: ToolCall[];
+  /** True while assistant response is still streaming in */
+  isStreaming?: boolean;
 }
 
 // Tool call and result


### PR DESCRIPTION
## Problem

`ChatMessage` in `types.ts` does not have an `isStreaming` field. The streaming state is needed in `App.tsx` (to accumulate chunks into a single message) and in `MessageList.tsx` (to show the typing cursor).

Because the field was missing from the type, the code used **unsafe TypeScript casts** in multiple places:

```ts
// Before — bypasses the type checker entirely
if ((last as ChatMessage & { isStreaming?: boolean }).isStreaming) { ... }
const isStreaming = (msg as ChatMessage & { isStreaming?: boolean }).isStreaming;
```

## Fix

Add `isStreaming?: boolean` to `ChatMessage` in `types.ts` and remove all cast workarounds:

```ts
// After — clean, type-safe
export interface ChatMessage {
  // ...existing fields...
  isStreaming?: boolean;
}
```

## Files changed
- `src/shared/types.ts` — add `isStreaming?: boolean` to `ChatMessage`
- `src/panel/App.tsx` — remove unsafe casts
- `src/panel/components/MessageList.tsx` — remove unsafe cast

---
> Part of the changes described in [patniko/github-copilot-browser#1](https://github.com/patniko/github-copilot-browser/issues/1)