### PR TITLE
feat: stop/abort button to interrupt generation mid-stream

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -76,6 +76,10 @@ async function handlePanelMessage(message: PanelMessage, port: chrome.runtime.Po
       break;
     }
 
+    case 'CANCEL_REQUEST':
+      nativeMessaging.send({ type: 'CANCEL_REQUEST', payload: message.payload });
+      break;
+
     case 'EXECUTE_TOOL':
       break;
   }

--- a/src/host/host.mjs
+++ b/src/host/host.mjs
@@ -210,6 +210,14 @@ async function handleMessage(message) {
       break;
     }
 
+    case 'CANCEL_REQUEST': {
+      if (session) {
+        await session.abort().catch(() => {});
+        sendMessage({ type: 'CHAT_RESPONSE', payload: { content: '' } });
+      }
+      break;
+    }
+
     default:
       sendMessage({ type: 'HOST_STATUS', payload: { connected: true, warning: `Unknown message type: ${message.type}` } });
   }

--- a/src/panel/App.tsx
+++ b/src/panel/App.tsx
@@ -205,6 +205,21 @@ export default function App() {
     }
   }, [connectionStatus]);
 
+  const handleStop = useCallback(() => {
+    copilotClient.cancelRequest(sessionId);
+    // Finalize any in-progress streaming message
+    setMessages((prev) => {
+      const last = prev[prev.length - 1];
+      if (last && last.role === 'assistant' && (last as ChatMessage & { isStreaming?: boolean }).isStreaming) {
+        return prev.map((m, i) =>
+          i === prev.length - 1 ? { ...m, isStreaming: undefined } : m
+        );
+      }
+      return prev;
+    });
+    setIsLoading(false);
+  }, [sessionId]);
+
   const handleNewSession = useCallback(async () => {
     setMessages([]);
     setIsLoading(false);
@@ -238,7 +253,7 @@ export default function App() {
         onShowHistory={() => setShowHistory(true)}
       />
       <MessageList messages={messages} isLoading={isLoading} />
-      <ChatInput onSend={handleSend} disabled={isLoading} />
+      <ChatInput onSend={handleSend} onStop={handleStop} isLoading={isLoading} disabled={isLoading} />
       <SessionHistory
         isOpen={showHistory}
         onClose={() => setShowHistory(false)}

--- a/src/panel/components/ChatInput.tsx
+++ b/src/panel/components/ChatInput.tsx
@@ -2,10 +2,12 @@ import React, { useState, useRef, useEffect } from 'react';
 
 interface ChatInputProps {
   onSend: (message: string) => void;
+  onStop?: () => void;
   disabled?: boolean;
+  isLoading?: boolean;
 }
 
-export default function ChatInput({ onSend, disabled }: ChatInputProps) {
+export default function ChatInput({ onSend, onStop, disabled, isLoading }: ChatInputProps) {
   const [input, setInput] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -39,21 +41,29 @@ export default function ChatInput({ onSend, disabled }: ChatInputProps) {
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Ask Copilot..."
-          disabled={disabled}
+          disabled={isLoading}
           rows={1}
-          className="flex-1 resize-none bg-transparent outline-none text-sm placeholder:opacity-50"
+          className="flex-1 resize-none bg-transparent outline-none text-sm placeholder:opacity-50 disabled:opacity-60"
           style={{ color: 'var(--copilot-text)', maxHeight: '150px' }}
         />
         <button
-          onClick={handleSubmit}
-          disabled={!input.trim() || disabled}
+          onClick={isLoading ? onStop : handleSubmit}
+          disabled={isLoading ? !onStop : (!input.trim() || disabled)}
           className="flex-shrink-0 rounded-md p-1.5 transition-colors disabled:opacity-30"
-          style={{ backgroundColor: input.trim() ? '#1f6feb' : 'transparent' }}
-          title="Send message"
+          style={{ backgroundColor: isLoading ? '#f85149' : (input.trim() ? '#1f6feb' : 'transparent') }}
+          title={isLoading ? 'Stop generation' : 'Send message'}
         >
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M1.724 1.053a.5.5 0 0 1 .552-.052l12 6.5a.5.5 0 0 1 0 .998l-12 6.5a.5.5 0 0 1-.722-.445V9.25l6.25-1.25-6.25-1.25V1.5a.5.5 0 0 1 .17-.447Z" />
-          </svg>
+          {isLoading ? (
+            // Stop icon (red square)
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+              <rect x="3" y="3" width="10" height="10" rx="1" />
+            </svg>
+          ) : (
+            // Send icon
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M1.724 1.053a.5.5 0 0 1 .552-.052l12 6.5a.5.5 0 0 1 0 .998l-12 6.5a.5.5 0 0 1-.722-.445V9.25l6.25-1.25-6.25-1.25V1.5a.5.5 0 0 1 .17-.447Z" />
+            </svg>
+          )}
         </button>
       </div>
       <p className="text-center mt-2 text-xs" style={{ color: 'var(--copilot-text-secondary)' }}>


### PR DESCRIPTION
## Feature

Adds a **stop button** that lets users interrupt a running Copilot response mid-stream without losing already-received text.

### UX behaviour

- While a response is streaming: the send button becomes a **red ■ stop button**
- Clicking stop: immediately halts generation, finalizes the partial message (content already received is kept), resets loading state
- The textarea is **disabled** while loading to prevent accidental double-sends

### Implementation

```
User clicks ■
  → ChatInput calls onStop()
  → App.tsx: copilotClient.cancelRequest(sessionId)
             + clears isStreaming flag on last message
             + setIsLoading(false)
  → service-worker: forwards CANCEL_REQUEST to host
  → host.mjs: session.abort() → sends CHAT_RESPONSE with empty content to signal end
```

### Depends on
- [PR-7](https://github.com/svg153/github-copilot-browser/pull/7) (`isStreaming` field on `ChatMessage`) — needed to finalize the streaming message correctly

## Files changed
- `src/panel/components/ChatInput.tsx` — stop button UI, `isLoading` prop, disabled textarea
- `src/panel/App.tsx` — `handleStop` callback, wire `onStop`/`isLoading` to ChatInput
- `src/background/service-worker.ts` — forward `CANCEL_REQUEST` to host
- `src/host/host.mjs` — handle `CANCEL_REQUEST`: call `session.abort()`, send terminal `CHAT_RESPONSE`

---
> Part of the changes described in [patniko/github-copilot-browser#1](https://github.com/patniko/github-copilot-browser/issues/1)