### PR TITLE
fix: approve all tool permission requests automatically

### DIFF
--- a/src/host/host.mjs
+++ b/src/host/host.mjs
@@ -1,5 +1,5 @@
 #!/opt/homebrew/bin/node
-import { CopilotClient } from '@github/copilot-sdk';
+import { CopilotClient, approveAll } from '@github/copilot-sdk';
 
 // ── Chrome Native Messaging Protocol ────────────────────────────────
 // 4-byte little-endian length prefix + JSON payload on stdin/stdout.
@@ -133,6 +133,7 @@ async function initialize() {
 
     session = await client.createSession({
       tools: browserTools,
+      onPermissionRequest: approveAll,
       systemMessage: {
         mode: 'append',
         content: [


### PR DESCRIPTION
## Problem

Every tool call fails silently. The LLM attempts to use a browser tool (e.g. `get_page_content`) and receives `"denied-no-approval-rule-and-could-not-request-from-user"` from the SDK — the extension appears to work but tools never execute.

## Root cause

`@github/copilot-sdk`'s `createSession()` defaults to **denying all tool permission requests** when no `permissionHandler` is provided.

## Fix

Import `approveAll` from `@github/copilot-sdk` and pass it as `onPermissionRequest` to `createSession()`.

```js
// Before
session = await client.createSession({ tools: browserTools, systemMessage: ... });

// After
import { approveAll } from '@github/copilot-sdk';
session = await client.createSession({ tools: browserTools, onPermissionRequest: approveAll, systemMessage: ... });
```

One line of code — but without it the extension is completely non-functional regardless of what tools are registered.

## Files changed
- `src/host/host.mjs`

---
> Part of the changes described in [patniko/github-copilot-browser#1](https://github.com/patniko/github-copilot-browser/issues/1)