### PR TITLE
feat: auto-discover Copilot CLI binary instead of hardcoding macOS path

### DIFF
--- a/src/host/host.mjs
+++ b/src/host/host.mjs
@@ -1,5 +1,8 @@
-#!/opt/homebrew/bin/node
+#!/usr/bin/env node
 import { CopilotClient } from '@github/copilot-sdk';
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
 
 // ── Chrome Native Messaging Protocol ────────────────────────────────
 // 4-byte little-endian length prefix + JSON payload on stdin/stdout.
@@ -123,10 +126,35 @@ const browserTools = [
   }),
 ];
 
+/**
+ * Discover the GitHub Copilot CLI binary.
+ * Checks common install locations before falling back to `which`/`where`.
+ */
+function findCopilotCli() {
+  const candidates = [
+    '/opt/homebrew/bin/copilot',          // macOS Homebrew (Apple Silicon)
+    '/usr/local/bin/copilot',             // macOS Homebrew (Intel) / Linux
+    '/usr/bin/copilot',                   // Linux system install
+    join(process.env.HOME || '', '.local/bin/copilot'), // user-local Linux
+    join(process.env.LOCALAPPDATA || '', 'Programs', 'GitHub Copilot CLI', 'copilot.exe'), // Windows
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return p;
+  }
+  // Fall back to PATH lookup
+  try {
+    const which = process.platform === 'win32' ? 'where copilot' : 'which copilot';
+    return execSync(which, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim().split('\n')[0];
+  } catch {
+    throw new Error('GitHub Copilot CLI not found. Install it and make sure it is in PATH.');
+  }
+}
+
 async function initialize() {
   try {
+    const cliPath = findCopilotCli();
     client = new CopilotClient({
-      cliPath: '/opt/homebrew/bin/copilot',
+      cliPath,
       logLevel: 'error',
       env: { ...process.env, PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH || '/usr/bin:/bin'}` },
     });


### PR DESCRIPTION
## Problem

The host fails to start on any platform other than **macOS Apple Silicon** with a cryptic `ENOENT` error and no helpful message.

Two hardcoded paths are the culprit:
- `cliPath: '/opt/homebrew/bin/copilot'` — same constraint

This means the extension is broken out-of-the-box on macOS Intel, Linux, Windows, and WSL.

## Fix

**1. Fix the shebang:**
```diff
```

**2. Add `findCopilotCli()`** that checks common install locations across all platforms before falling back to `which`/`where`:

| Platform | Locations checked |
|----------|------------------|
| macOS Apple Silicon | `/opt/homebrew/bin/copilot` |
| macOS Intel / Linux | `/usr/local/bin/copilot`, `/usr/bin/copilot` |
| Linux (user install) | `~/.local/bin/copilot` |
| Windows | `%LOCALAPPDATA%\Programs\GitHub Copilot CLI\copilot.exe` |
| Any | `which copilot` / `where copilot` (PATH fallback) |

If nothing is found, throws a clear error: _"GitHub Copilot CLI not found. Install it and make sure it is in PATH."_

## Files changed
- `src/host/host.mjs`

---
> Part of the changes described in [patniko/github-copilot-browser#1](https://github.com/patniko/github-copilot-browser/issues/1)